### PR TITLE
Fix tests and don't call OnDisconnect early

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -341,13 +341,13 @@ func (c *Client) Incoming() {
 					pc.WriteTo(c.Conn)
 				}
 			case packets.DISCONNECT:
-				if c.OnDisconnect != nil {
-					go c.OnDisconnect(*recv.Content.(*packets.Disconnect))
-				}
 				if c.raCtx != nil {
 					c.raCtx.Return <- *recv
 				}
 				c.Error(fmt.Errorf("received server initiated disconnect"))
+				if c.OnDisconnect != nil {
+					go c.OnDisconnect(*recv.Content.(*packets.Disconnect))
+				}
 			}
 		}
 	}

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	c := NewClient()
+	c := NewClient(ClientConfig{})
 
 	require.NotNil(t, c)
 	require.NotNil(t, c.stop)
@@ -56,10 +56,10 @@ func TestClientConnect(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+	})
 	require.NotNil(t, c)
-
-	c.Conn = ts.ClientConn()
 
 	cp := &Connect{
 		KeepAlive:  30,
@@ -94,10 +94,11 @@ func TestClientSubscribe(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+	})
 	require.NotNil(t, c)
 
-	c.Conn = ts.ClientConn()
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -126,10 +127,11 @@ func TestClientUnsubscribe(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+	})
 	require.NotNil(t, c)
 
-	c.Conn = ts.ClientConn()
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -157,10 +159,11 @@ func TestClientPublishQoS1(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+	})
 	require.NotNil(t, c)
 
-	c.Conn = ts.ClientConn()
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	go c.Incoming()
@@ -193,10 +196,11 @@ func TestClientPublishQoS2(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+	})
 	require.NotNil(t, c)
 
-	c.Conn = ts.ClientConn()
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	go c.Incoming()
@@ -222,17 +226,17 @@ func TestClientReceiveQoS1(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+		Router: NewSingleHandlerRouter(func(p *Publish) {
+			assert.Equal(t, "test/1", p.Topic)
+			assert.Equal(t, "test payload", string(p.Payload))
+			assert.Equal(t, byte(1), p.QoS)
+			close(rChan)
+		}),
+	})
 	require.NotNil(t, c)
 
-	c.Router = NewSingleHandlerRouter(func(p *Publish) {
-		assert.Equal(t, "test/1", p.Topic)
-		assert.Equal(t, "test payload", string(p.Payload))
-		assert.Equal(t, byte(1), p.QoS)
-		close(rChan)
-	})
-
-	c.Conn = ts.ClientConn()
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	go c.Incoming()
@@ -254,17 +258,17 @@ func TestClientReceiveQoS2(t *testing.T) {
 	go ts.Run()
 	defer ts.Stop()
 
-	c := NewClient()
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+		Router: NewSingleHandlerRouter(func(p *Publish) {
+			assert.Equal(t, "test/2", p.Topic)
+			assert.Equal(t, "test payload", string(p.Payload))
+			assert.Equal(t, byte(2), p.QoS)
+			close(rChan)
+		}),
+	})
 	require.NotNil(t, c)
 
-	c.Router = NewSingleHandlerRouter(func(p *Publish) {
-		assert.Equal(t, "test/2", p.Topic)
-		assert.Equal(t, "test payload", string(p.Payload))
-		assert.Equal(t, byte(2), p.QoS)
-		close(rChan)
-	})
-
-	c.Conn = ts.ClientConn()
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	go c.Incoming()


### PR DESCRIPTION
The call to the OnDisconnect handler was scheduled before the disconnect
process had completed, because the user may legitimately want to call
Connect() again in this handler don't call it until disconnected.