### PR TITLE
Check the ping channel is not nil in Stop()

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -57,8 +57,12 @@ type (
 // WriteTo operates on a FixedHeader and takes the option values and produces
 // the wire format byte that represents these.
 func (f *FixedHeader) WriteTo(w io.Writer) (int64, error) {
-	w.Write([]byte{byte(f.Type)<<4 | f.Flags})
-	w.Write(encodeVBI(f.remainingLength))
+	if _, err := w.Write([]byte{byte(f.Type)<<4 | f.Flags}); err != nil {
+		return 0, err
+	}
+	if _, err := w.Write(encodeVBI(f.remainingLength)); err != nil {
+		return 0, err
+	}
 
 	return 0, nil
 }
@@ -196,7 +200,9 @@ func (c *ControlPacket) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	var header bytes.Buffer
-	c.FixedHeader.WriteTo(&header)
+	if _, err := c.FixedHeader.WriteTo(&header); err != nil {
+		return 0, err
+	}
 
 	buffers = append(net.Buffers{header.Bytes()}, buffers...)
 

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -275,11 +275,12 @@ func TestClientReceiveQoS0(t *testing.T) {
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
-	ts.SendPacket(&packets.Publish{
+	err := ts.SendPacket(&packets.Publish{
 		Topic:   "test/0",
 		QoS:     0,
 		Payload: []byte("test payload"),
 	})
+	require.NoError(t, err)
 
 	<-rChan
 }
@@ -308,11 +309,12 @@ func TestClientReceiveQoS1(t *testing.T) {
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
-	ts.SendPacket(&packets.Publish{
+	err := ts.SendPacket(&packets.Publish{
 		Topic:   "test/1",
 		QoS:     1,
 		Payload: []byte("test payload"),
 	})
+	require.NoError(t, err)
 
 	<-rChan
 }
@@ -341,11 +343,12 @@ func TestClientReceiveQoS2(t *testing.T) {
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
-	ts.SendPacket(&packets.Publish{
+	err := ts.SendPacket(&packets.Publish{
 		Topic:   "test/2",
 		QoS:     2,
 		Payload: []byte("test payload"),
 	})
+	require.NoError(t, err)
 
 	<-rChan
 }
@@ -373,12 +376,13 @@ func TestReceiveServerDisconnect(t *testing.T) {
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
-	ts.SendPacket(&packets.Disconnect{
+	err := ts.SendPacket(&packets.Disconnect{
 		ReasonCode: packets.DisconnectServerShuttingDown,
 		Properties: &packets.Properties{
 			ReasonString: "GONE!",
 		},
 	})
+	require.NoError(t, err)
 
 	<-rChan
 }

--- a/paho/cmd/chat/main.go
+++ b/paho/cmd/chat/main.go
@@ -72,7 +72,10 @@ func main() {
 		fmt.Println("signal received, exiting")
 		if c != nil {
 			d := &paho.Disconnect{ReasonCode: 0}
-			c.Disconnect(d)
+			err := c.Disconnect(d)
+			if err != nil {
+				log.Fatalf("failed to send Disconnect: %s", err)
+			}
 		}
 		os.Exit(0)
 	}()

--- a/paho/cmd/rpc/main.go
+++ b/paho/cmd/rpc/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/eclipse/paho.golang/paho"
 	"github.com/eclipse/paho.golang/paho/extensions/rpc"
@@ -73,13 +74,16 @@ func listener(server, rTopic, username, password string) {
 				}
 
 				body, _ := json.Marshal(resp)
-				c.Publish(context.Background(), &paho.Publish{
+				_, err := c.Publish(context.Background(), &paho.Publish{
 					Properties: &paho.PublishProperties{
 						CorrelationData: m.Properties.CorrelationData,
 					},
 					Topic:   m.Properties.ResponseTopic,
 					Payload: body,
 				})
+				if err != nil {
+					log.Fatalf("failed to publish message: %s", err)
+				}
 			}
 		})
 
@@ -108,15 +112,19 @@ func listener(server, rTopic, username, password string) {
 
 		fmt.Printf("Connected to %s\n", server)
 
-		c.Subscribe(context.Background(), &paho.Subscribe{
+		_, err = c.Subscribe(context.Background(), &paho.Subscribe{
 			Subscriptions: map[string]paho.SubscribeOptions{
 				rTopic: paho.SubscribeOptions{QoS: 0},
 			},
 		})
+		if err != nil {
+			log.Fatalf("failed to subscribe: %s", err)
+		}
 
 		v.Done()
 
 		for {
+			time.Sleep(1 * time.Second)
 		}
 	}()
 

--- a/paho/cmd/stdoutsub/main.go
+++ b/paho/cmd/stdoutsub/main.go
@@ -22,7 +22,10 @@ func main() {
 	password := flag.String("password", "", "Password to match username")
 	flag.Parse()
 
-	paho.SetDebugLogger(log.New(os.Stderr, "SUB: ", log.LstdFlags))
+	logger := log.New(os.Stdout, "SUB: ", log.LstdFlags)
+
+	paho.SetDebugLogger(logger)
+	paho.SetErrorLogger(logger)
 	msgChan := make(chan *paho.Publish)
 
 	conn, err := net.Dial("tcp", *server)

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -83,6 +83,9 @@ func (p *PingHandler) Start(c net.Conn, pt time.Duration) {
 // Stop is the library provided Pinger's implementation of
 // the required interface function()
 func (p *PingHandler) Stop() {
+	if p.stop == nil {
+		return
+	}
 	debug.Println("pingHandler stopping")
 	select {
 	case <-p.stop:

--- a/paho/server_test.go
+++ b/paho/server_test.go
@@ -45,8 +45,10 @@ func (t *testServer) SetResponse(pt packets.PacketType, p packets.Packet) {
 	t.responses[pt] = p
 }
 
-func (t *testServer) SendPacket(p packets.Packet) {
-	p.WriteTo(t.conn)
+func (t *testServer) SendPacket(p packets.Packet) error {
+	_, err := p.WriteTo(t.conn)
+
+	return err
 }
 
 func (t *testServer) Stop() {


### PR DESCRIPTION
As reported in #19 the cleanup function in Connect will attempt to Stop
the PingHandler, as it happens the PingHandler will not have been
started at any point before when cleanup() may be called. However
Incoming() will have been started and will also attempt to Stop()
PingHandler which in the issue given will still have a nil channel
Also I've added some more error checks.