### PR TITLE
Add extension to provide automatic topic aliasing

### DIFF
--- a/paho/cmd/chat/main.go
+++ b/paho/cmd/chat/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	if _, err := c.Subscribe(context.Background(), &paho.Subscribe{
 		Subscriptions: map[string]paho.SubscribeOptions{
-			*topic: paho.SubscribeOptions{QoS: byte(*qos), NoLocal: true},
+			*topic: {QoS: byte(*qos), NoLocal: true},
 		},
 	}); err != nil {
 		log.Fatalln(err)

--- a/paho/cp_publish.go
+++ b/paho/cp_publish.go
@@ -105,6 +105,9 @@ func (p *Publish) String() string {
 	if p.Properties.CorrelationData != nil {
 		fmt.Fprintf(&b, "CorrelationData: %v\n", p.Properties.CorrelationData)
 	}
+	if p.Properties.TopicAlias != nil {
+		fmt.Fprintf(&b, "TopicAlias: %d\n", p.Properties.TopicAlias)
+	}
 	if p.Properties.SubscriptionIdentifier != nil {
 		fmt.Fprintf(&b, "SubscriptionIdentifier: %v\n", p.Properties.SubscriptionIdentifier)
 	}

--- a/paho/extensions/rpc/rpc.go
+++ b/paho/extensions/rpc/rpc.go
@@ -27,7 +27,7 @@ func NewHandler(c *paho.Client) (*Handler, error) {
 
 	_, err := c.Subscribe(context.Background(), &paho.Subscribe{
 		Subscriptions: map[string]paho.SubscribeOptions{
-			fmt.Sprintf("%s/responses", c.ClientID): paho.SubscribeOptions{QoS: 1},
+			fmt.Sprintf("%s/responses", c.ClientID): {QoS: 1},
 		},
 	})
 	if err != nil {

--- a/paho/extensions/topicaliases/topicliases.go
+++ b/paho/extensions/topicaliases/topicliases.go
@@ -1,0 +1,98 @@
+package topicaliases
+
+import (
+	"sync"
+
+	"github.com/eclipse/paho.golang/paho"
+)
+
+type TAHandler struct {
+	sync.Mutex
+	aliasMax uint16
+	aliases  []string
+}
+
+func NewTAHandler(max uint16) *TAHandler {
+	return &TAHandler{
+		aliasMax: max + 1,
+		aliases:  make([]string, max+1),
+	}
+}
+
+// GetTopic will return the topic for a given alias number
+func (t *TAHandler) GetTopic(a uint16) string {
+	if a > t.aliasMax {
+		return ""
+	}
+	t.Lock()
+	defer t.Unlock()
+
+	return t.aliases[a]
+}
+
+// GetAlias will return the alias for a given topic string
+func (t *TAHandler) GetAlias(topic string) uint16 {
+	for i, s := range t.aliases {
+		if s == topic {
+			return uint16(i)
+		}
+	}
+
+	return 0
+}
+
+// SetAlias will request an alias number for a given string
+func (t *TAHandler) SetAlias(topic string) uint16 {
+	t.Lock()
+	defer t.Unlock()
+
+	for i := uint16(1); i <= t.aliasMax; i++ {
+		if t.aliases[i] == "" {
+			t.aliases[i] = topic
+			return i
+		}
+	}
+
+	return 0
+}
+
+// ResetAlias reassigns a given alias number for a new topic
+func (t *TAHandler) ResetAlias(topic string, a uint16) {
+	t.Lock()
+	defer t.Unlock()
+
+	t.aliases[a] = topic
+}
+
+// PublishHook is designed to be given to an MQTT client and will be executed
+// before a publish is sent allowing it to modify the Properties of the packet.
+// In this case it allows the Topic Alias Handler to automatically replace topic
+// names with alias numbers
+func (t *TAHandler) PublishHook(p *paho.Publish) {
+	//p.Topic is always not "" as the default publish checks before calling hooks
+	if p.Properties != nil && p.Properties.TopicAlias != nil {
+		//topic string is not empty and topic alias is set, reset the alias value.
+		t.ResetAlias(p.Topic, *p.Properties.TopicAlias)
+		return
+	}
+
+	//we already have an alias, set it and unset the topic
+	if a := t.GetAlias(p.Topic); a != 0 {
+		if p.Properties == nil {
+			p.Properties = &paho.PublishProperties{}
+		}
+		p.Properties.TopicAlias = paho.Uint16(a)
+		p.Topic = ""
+		return
+	}
+
+	//we don't have an alias, try and get one
+	if a := t.SetAlias(p.Topic); a != 0 {
+		if p.Properties == nil {
+			p.Properties = &paho.PublishProperties{}
+		}
+		p.Properties.TopicAlias = paho.Uint16(a)
+		p.Topic = ""
+		return
+	}
+}

--- a/paho/extensions/topicaliases/topicliases_test.go
+++ b/paho/extensions/topicaliases/topicliases_test.go
@@ -1,0 +1,104 @@
+package topicaliases
+
+import (
+	"testing"
+
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTAHandler_PublishHook(t *testing.T) {
+	tests := []struct {
+		name            string
+		aliasMax        uint16
+		aliases         []string
+		p               *paho.Publish
+		expected        *paho.Publish
+		expectedAliases []string
+	}{
+		{
+			name:     "has alias",
+			aliasMax: 4,
+			aliases:  []string{"", "", "", "test", ""},
+			p: &paho.Publish{
+				Topic: "test",
+			},
+			expected: &paho.Publish{
+				Properties: &paho.PublishProperties{
+					TopicAlias: paho.Uint16(3),
+				},
+			},
+			expectedAliases: []string{"", "", "", "test", ""},
+		},
+		{
+			name:     "reset alias",
+			aliasMax: 4,
+			aliases:  []string{"", "", "", "test", ""},
+			p: &paho.Publish{
+				Topic: "test2",
+				Properties: &paho.PublishProperties{
+					TopicAlias: paho.Uint16(3),
+				},
+			},
+			expected: &paho.Publish{
+				Topic: "test2",
+				Properties: &paho.PublishProperties{
+					TopicAlias: paho.Uint16(3),
+				},
+			},
+			expectedAliases: []string{"", "", "", "test2", ""},
+		},
+		{
+			name:     "no alias",
+			aliasMax: 4,
+			aliases:  []string{"", "", "", "", ""},
+			p: &paho.Publish{
+				Topic: "test",
+			},
+			expected: &paho.Publish{
+				Properties: &paho.PublishProperties{
+					TopicAlias: paho.Uint16(1),
+				},
+			},
+			expectedAliases: []string{"", "test", "", "", ""},
+		},
+		{
+			name:     "properties no alias",
+			aliasMax: 4,
+			aliases:  []string{"", "", "", "", ""},
+			p: &paho.Publish{
+				Topic:      "test",
+				Properties: &paho.PublishProperties{},
+			},
+			expected: &paho.Publish{
+				Properties: &paho.PublishProperties{
+					TopicAlias: paho.Uint16(1),
+				},
+			},
+			expectedAliases: []string{"", "test", "", "", ""},
+		},
+		{
+			name:     "no alias free",
+			aliasMax: 1,
+			aliases:  []string{"", "full"},
+			p: &paho.Publish{
+				Topic: "test",
+			},
+			expected: &paho.Publish{
+				Topic: "test",
+			},
+			expectedAliases: []string{"", "full"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ta := &TAHandler{
+				aliasMax: tt.aliasMax,
+				aliases:  tt.aliases,
+			}
+			ta.PublishHook(tt.p)
+			assert.Equal(t, tt.expected, tt.p)
+			assert.Equal(t, tt.expectedAliases, ta.aliases)
+		})
+	}
+}


### PR DESCRIPTION
Added a publishHook function to clientconfig that if set is called
before the publish is sent, this function can modify the Publish and is
used in the extension to do automatic topic aliasing

#29