### PR TITLE
fix: session expiry interval is valid for CONNACK

### DIFF
--- a/packets/properties.go
+++ b/packets/properties.go
@@ -674,7 +674,7 @@ var ValidProperties = map[byte]map[byte]struct{}{
 	PropCorrelationData:        {PUBLISH: {}},
 	PropTopicAlias:             {PUBLISH: {}},
 	PropSubscriptionIdentifier: {PUBLISH: {}, SUBSCRIBE: {}},
-	PropSessionExpiryInterval:  {CONNECT: {}, DISCONNECT: {}},
+	PropSessionExpiryInterval:  {CONNECT: {}, CONNACK: {}, DISCONNECT: {}},
 	PropAssignedClientID:       {CONNACK: {}},
 	PropServerKeepAlive:        {CONNACK: {}},
 	PropWildcardSubAvailable:   {CONNACK: {}},


### PR DESCRIPTION
This PR will fix https://github.com/eclipse/paho.golang/issues/32
