### PR TITLE
Make user properties a slice of struct not map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/eclipse/paho.golang
 
+go 1.15
+
 require (
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -11,3 +11,5 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03i
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/packets/connect.go
+++ b/packets/connect.go
@@ -92,7 +92,7 @@ func (c *Connect) Unpack(r *bytes.Buffer) error {
 	}
 
 	if c.WillFlag {
-		c.WillProperties = &Properties{User: make(map[string]string)}
+		c.WillProperties = &Properties{}
 		err = c.WillProperties.Unpack(r, CONNECT)
 		if err != nil {
 			return err

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -104,43 +104,43 @@ func NewControlPacket(t byte) *ControlPacket {
 		cp.Content = &Connect{
 			ProtocolName:    "MQTT",
 			ProtocolVersion: 5,
-			Properties:      &Properties{User: make(map[string]string)},
+			Properties:      &Properties{},
 		}
 	case CONNACK:
-		cp.Content = &Connack{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Connack{Properties: &Properties{}}
 	case PUBLISH:
-		cp.Content = &Publish{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Publish{Properties: &Properties{}}
 	case PUBACK:
-		cp.Content = &Puback{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Puback{Properties: &Properties{}}
 	case PUBREC:
-		cp.Content = &Pubrec{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Pubrec{Properties: &Properties{}}
 	case PUBREL:
 		cp.Flags = 2
-		cp.Content = &Pubrel{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Pubrel{Properties: &Properties{}}
 	case PUBCOMP:
-		cp.Content = &Pubcomp{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Pubcomp{Properties: &Properties{}}
 	case SUBSCRIBE:
 		cp.Flags = 2
 		cp.Content = &Subscribe{
 			Subscriptions: make(map[string]SubOptions),
-			Properties:    &Properties{User: make(map[string]string)},
+			Properties:    &Properties{},
 		}
 	case SUBACK:
-		cp.Content = &Suback{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Suback{Properties: &Properties{}}
 	case UNSUBSCRIBE:
 		cp.Flags = 2
-		cp.Content = &Unsubscribe{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Unsubscribe{Properties: &Properties{}}
 	case UNSUBACK:
-		cp.Content = &Unsuback{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Unsuback{Properties: &Properties{}}
 	case PINGREQ:
 		cp.Content = &Pingreq{}
 	case PINGRESP:
 		cp.Content = &Pingresp{}
 	case DISCONNECT:
-		cp.Content = &Disconnect{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Disconnect{Properties: &Properties{}}
 	case AUTH:
 		cp.Flags = 1
-		cp.Content = &Auth{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Auth{Properties: &Properties{}}
 	default:
 		return nil
 	}
@@ -167,43 +167,43 @@ func ReadPacket(r io.Reader) (*ControlPacket, error) {
 		cp.Content = &Connect{
 			ProtocolName:    "MQTT",
 			ProtocolVersion: 5,
-			Properties:      &Properties{User: make(map[string]string)},
+			Properties:      &Properties{},
 		}
 	case CONNACK:
-		cp.Content = &Connack{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Connack{Properties: &Properties{}}
 	case PUBLISH:
-		cp.Content = &Publish{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Publish{Properties: &Properties{}}
 	case PUBACK:
-		cp.Content = &Puback{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Puback{Properties: &Properties{}}
 	case PUBREC:
-		cp.Content = &Pubrec{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Pubrec{Properties: &Properties{}}
 	case PUBREL:
 		cp.Flags = 2
-		cp.Content = &Pubrel{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Pubrel{Properties: &Properties{}}
 	case PUBCOMP:
-		cp.Content = &Pubcomp{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Pubcomp{Properties: &Properties{}}
 	case SUBSCRIBE:
 		cp.Flags = 2
 		cp.Content = &Subscribe{
 			Subscriptions: make(map[string]SubOptions),
-			Properties:    &Properties{User: make(map[string]string)},
+			Properties:    &Properties{},
 		}
 	case SUBACK:
-		cp.Content = &Suback{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Suback{Properties: &Properties{}}
 	case UNSUBSCRIBE:
 		cp.Flags = 2
-		cp.Content = &Unsubscribe{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Unsubscribe{Properties: &Properties{}}
 	case UNSUBACK:
-		cp.Content = &Unsuback{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Unsuback{Properties: &Properties{}}
 	case PINGREQ:
 		cp.Content = &Pingreq{}
 	case PINGRESP:
 		cp.Content = &Pingresp{}
 	case DISCONNECT:
-		cp.Content = &Disconnect{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Disconnect{Properties: &Properties{}}
 	case AUTH:
 		cp.Flags = 1
-		cp.Content = &Auth{Properties: &Properties{User: make(map[string]string)}}
+		cp.Content = &Auth{Properties: &Properties{}}
 	default:
 		return nil, fmt.Errorf("unknown packet type %d requested", pt)
 	}

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -158,7 +158,7 @@ func TestNewControlPacket(t *testing.T) {
 				Content: &Connect{
 					ProtocolName:    "MQTT",
 					ProtocolVersion: 5,
-					Properties:      &Properties{User: make(map[string]string)},
+					Properties:      &Properties{},
 				},
 			},
 		},
@@ -167,7 +167,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: CONNACK,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: CONNACK},
-				Content:     &Connack{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Connack{Properties: &Properties{}},
 			},
 		},
 		{
@@ -175,7 +175,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: PUBLISH,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: PUBLISH},
-				Content:     &Publish{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Publish{Properties: &Properties{}},
 			},
 		},
 		{
@@ -183,7 +183,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: PUBACK,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: PUBACK},
-				Content:     &Puback{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Puback{Properties: &Properties{}},
 			},
 		},
 		{
@@ -191,7 +191,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: PUBREC,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: PUBREC},
-				Content:     &Pubrec{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Pubrec{Properties: &Properties{}},
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: PUBREL,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: PUBREL, Flags: 2},
-				Content:     &Pubrel{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Pubrel{Properties: &Properties{}},
 			},
 		},
 		{
@@ -207,7 +207,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: PUBCOMP,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: PUBCOMP},
-				Content:     &Pubcomp{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Pubcomp{Properties: &Properties{}},
 			},
 		},
 		{
@@ -216,7 +216,7 @@ func TestNewControlPacket(t *testing.T) {
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: SUBSCRIBE, Flags: 2},
 				Content: &Subscribe{
-					Properties:    &Properties{User: make(map[string]string)},
+					Properties:    &Properties{},
 					Subscriptions: make(map[string]SubOptions),
 				},
 			},
@@ -226,7 +226,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: SUBACK,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: SUBACK},
-				Content:     &Suback{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Suback{Properties: &Properties{}},
 			},
 		},
 		{
@@ -234,7 +234,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: UNSUBSCRIBE,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: UNSUBSCRIBE, Flags: 2},
-				Content:     &Unsubscribe{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Unsubscribe{Properties: &Properties{}},
 			},
 		},
 		{
@@ -242,7 +242,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: UNSUBACK,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: UNSUBACK},
-				Content:     &Unsuback{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Unsuback{Properties: &Properties{}},
 			},
 		},
 		{
@@ -266,7 +266,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: DISCONNECT,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: DISCONNECT},
-				Content:     &Disconnect{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Disconnect{Properties: &Properties{}},
 			},
 		},
 		{
@@ -274,7 +274,7 @@ func TestNewControlPacket(t *testing.T) {
 			args: AUTH,
 			want: &ControlPacket{
 				FixedHeader: FixedHeader{Type: AUTH, Flags: 1},
-				Content:     &Auth{Properties: &Properties{User: make(map[string]string)}},
+				Content:     &Auth{Properties: &Properties{}},
 			},
 		},
 		{

--- a/paho/cmd/chat/main.go
+++ b/paho/cmd/chat/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	c := paho.NewClient(paho.ClientConfig{
 		Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
-			log.Printf("%s : %s", m.Properties.User["chatname"], string(m.Payload))
+			log.Printf("%s : %s", m.Properties.User.Get("chatname"), string(m.Payload))
 		}),
 		Conn: conn,
 	})
@@ -96,15 +96,14 @@ func main() {
 			os.Exit(0)
 		}
 
+		props := &paho.PublishProperties{}
+		props.User.Add("chatname", *name)
+
 		pb := &paho.Publish{
-			Topic:   *topic,
-			QoS:     byte(*qos),
-			Payload: []byte(message),
-			Properties: &paho.PublishProperties{
-				User: map[string]string{
-					"chatname": *name,
-				},
-			},
+			Topic:      *topic,
+			QoS:        byte(*qos),
+			Payload:    []byte(message),
+			Properties: props,
 		}
 
 		if _, err = c.Publish(context.Background(), pb); err != nil {

--- a/paho/cp_auth.go
+++ b/paho/cp_auth.go
@@ -15,7 +15,7 @@ type (
 		AuthData     []byte
 		AuthMethod   string
 		ReasonString string
-		User         map[string]string
+		User         UserProperties
 	}
 )
 
@@ -27,7 +27,7 @@ func (a *Auth) InitProperties(p *packets.Properties) {
 		AuthMethod:   p.AuthMethod,
 		AuthData:     p.AuthData,
 		ReasonString: p.ReasonString,
-		User:         p.User,
+		User:         UserPropertiesFromPacketUser(p.User),
 	}
 }
 
@@ -50,7 +50,7 @@ func (a *Auth) Packet() *packets.Auth {
 			AuthMethod:   a.Properties.AuthMethod,
 			AuthData:     a.Properties.AuthData,
 			ReasonString: a.Properties.ReasonString,
-			User:         a.Properties.User,
+			User:         a.Properties.User.ToPacketProperties(),
 		}
 	}
 
@@ -73,7 +73,7 @@ func AuthResponseFromPacketAuth(a *packets.Auth) *AuthResponse {
 		ReasonCode: a.ReasonCode,
 		Properties: &AuthProperties{
 			ReasonString: a.Properties.ReasonString,
-			User:         a.Properties.User,
+			User:         UserPropertiesFromPacketUser(a.Properties.User),
 		},
 	}
 }
@@ -86,7 +86,7 @@ func AuthResponseFromPacketDisconnect(d *packets.Disconnect) *AuthResponse {
 		ReasonCode: d.ReasonCode,
 		Properties: &AuthProperties{
 			ReasonString: d.Properties.ReasonString,
-			User:         d.Properties.User,
+			User:         UserPropertiesFromPacketUser(d.Properties.User),
 		},
 	}
 }

--- a/paho/cp_connack.go
+++ b/paho/cp_connack.go
@@ -25,7 +25,7 @@ type (
 		TopicAliasMaximum     *uint16
 		ServerKeepAlive       *uint16
 		MaximumQoS            *byte
-		User                  map[string]string
+		User                  UserProperties
 		WildcardSubAvailable  bool
 		SubIDAvailable        bool
 		SharedSubAvailable    bool
@@ -54,7 +54,7 @@ func (c *Connack) InitProperties(p *packets.Properties) {
 		TopicAliasMaximum:     p.TopicAliasMaximum,
 		MaximumQoS:            p.MaximumQOS,
 		MaximumPacketSize:     p.MaximumPacketSize,
-		User:                  p.User,
+		User:                  UserPropertiesFromPacketUser(p.User),
 	}
 
 	if p.WildcardSubAvailable != nil {

--- a/paho/cp_connect.go
+++ b/paho/cp_connect.go
@@ -28,7 +28,7 @@ type (
 		TopicAliasMaximum     *uint16
 		MaximumQOS            *byte
 		MaximumPacketSize     *uint32
-		User                  map[string]string
+		User                  UserProperties
 		RequestProblemInfo    bool
 		RequestResponseInfo   bool
 	}
@@ -49,7 +49,7 @@ func (c *Connect) InitProperties(p *packets.Properties) {
 		TopicAliasMaximum:     p.TopicAliasMaximum,
 		MaximumQOS:            p.MaximumQOS,
 		MaximumPacketSize:     p.MaximumPacketSize,
-		User:                  p.User,
+		User:                  UserPropertiesFromPacketUser(p.User),
 	}
 
 	if p.RequestResponseInfo != nil {
@@ -71,7 +71,7 @@ func (c *Connect) InitWillProperties(p *packets.Properties) {
 		ContentType:       p.ContentType,
 		ResponseTopic:     p.ResponseTopic,
 		CorrelationData:   p.CorrelationData,
-		User:              p.User,
+		User:              UserPropertiesFromPacketUser(p.User),
 	}
 }
 
@@ -124,7 +124,7 @@ func (c *Connect) Packet() *packets.Connect {
 			TopicAliasMaximum:     c.Properties.TopicAliasMaximum,
 			MaximumQOS:            c.Properties.MaximumQOS,
 			MaximumPacketSize:     c.Properties.MaximumPacketSize,
-			User:                  c.Properties.User,
+			User:                  c.Properties.User.ToPacketProperties(),
 		}
 		if c.Properties.RequestResponseInfo {
 			v.Properties.RequestResponseInfo = Byte(1)
@@ -148,7 +148,7 @@ func (c *Connect) Packet() *packets.Connect {
 				ContentType:       c.WillProperties.ContentType,
 				ResponseTopic:     c.WillProperties.ResponseTopic,
 				CorrelationData:   c.WillProperties.CorrelationData,
-				User:              c.WillProperties.User,
+				User:              c.WillProperties.User.ToPacketProperties(),
 			}
 		}
 	}
@@ -175,6 +175,6 @@ type (
 		ContentType       string
 		ResponseTopic     string
 		CorrelationData   []byte
-		User              map[string]string
+		User              UserProperties
 	}
 )

--- a/paho/cp_disconnect.go
+++ b/paho/cp_disconnect.go
@@ -15,7 +15,7 @@ type (
 		ServerReference       string
 		ReasonString          string
 		SessionExpiryInterval *uint32
-		User                  map[string]string
+		User                  UserProperties
 	}
 )
 
@@ -27,7 +27,7 @@ func (d *Disconnect) InitProperties(p *packets.Properties) {
 		SessionExpiryInterval: p.SessionExpiryInterval,
 		ServerReference:       p.ServerReference,
 		ReasonString:          p.ReasonString,
-		User:                  p.User,
+		User:                  UserPropertiesFromPacketUser(p.User),
 	}
 }
 
@@ -50,7 +50,7 @@ func (d *Disconnect) Packet() *packets.Disconnect {
 			SessionExpiryInterval: d.Properties.SessionExpiryInterval,
 			ServerReference:       d.Properties.ServerReference,
 			ReasonString:          d.Properties.ReasonString,
-			User:                  d.Properties.User,
+			User:                  d.Properties.User.ToPacketProperties(),
 		}
 	}
 

--- a/paho/cp_publish.go
+++ b/paho/cp_publish.go
@@ -27,7 +27,7 @@ type (
 		MessageExpiry          *uint32
 		SubscriptionIdentifier *uint32
 		TopicAlias             *uint16
-		User                   map[string]string
+		User                   UserProperties
 	}
 )
 
@@ -43,7 +43,7 @@ func (p *Publish) InitProperties(prop *packets.Properties) {
 		CorrelationData:        prop.CorrelationData,
 		TopicAlias:             prop.TopicAlias,
 		SubscriptionIdentifier: prop.SubscriptionIdentifier,
-		User:                   prop.User,
+		User:                   UserPropertiesFromPacketUser(prop.User),
 	}
 }
 
@@ -79,7 +79,7 @@ func (p *Publish) Packet() *packets.Publish {
 			CorrelationData:        p.Properties.CorrelationData,
 			TopicAlias:             p.Properties.TopicAlias,
 			SubscriptionIdentifier: p.Properties.SubscriptionIdentifier,
-			User:                   p.Properties.User,
+			User:                   p.Properties.User.ToPacketProperties(),
 		}
 	}
 
@@ -111,8 +111,8 @@ func (p *Publish) String() string {
 	if p.Properties.SubscriptionIdentifier != nil {
 		fmt.Fprintf(&b, "SubscriptionIdentifier: %v\n", p.Properties.SubscriptionIdentifier)
 	}
-	for k, v := range p.Properties.User {
-		fmt.Fprintf(&b, "User: %s : %s\n", k, v)
+	for _, v := range p.Properties.User {
+		fmt.Fprintf(&b, "User: %s : %s\n", v.Key, v.Value)
 	}
 	b.WriteString(string(p.Payload))
 

--- a/paho/cp_pubresp.go
+++ b/paho/cp_pubresp.go
@@ -14,7 +14,7 @@ type (
 	// a response to a QoS1 or QoS2 Publish
 	PublishResponseProperties struct {
 		ReasonString string
-		User         map[string]string
+		User         UserProperties
 	}
 )
 
@@ -25,7 +25,7 @@ func PublishResponseFromPuback(pa *packets.Puback) *PublishResponse {
 		ReasonCode: pa.ReasonCode,
 		Properties: &PublishResponseProperties{
 			ReasonString: pa.Properties.ReasonString,
-			User:         pa.Properties.User,
+			User:         UserPropertiesFromPacketUser(pa.Properties.User),
 		},
 	}
 }
@@ -37,7 +37,7 @@ func PublishResponseFromPubcomp(pc *packets.Pubcomp) *PublishResponse {
 		ReasonCode: pc.ReasonCode,
 		Properties: &PublishResponseProperties{
 			ReasonString: pc.Properties.ReasonString,
-			User:         pc.Properties.User,
+			User:         UserPropertiesFromPacketUser(pc.Properties.User),
 		},
 	}
 }
@@ -49,7 +49,7 @@ func PublishResponseFromPubrec(pr *packets.Pubrec) *PublishResponse {
 		ReasonCode: pr.ReasonCode,
 		Properties: &PublishResponseProperties{
 			ReasonString: pr.Properties.ReasonString,
-			User:         pr.Properties.User,
+			User:         UserPropertiesFromPacketUser(pr.Properties.User),
 		},
 	}
 }

--- a/paho/cp_suback.go
+++ b/paho/cp_suback.go
@@ -13,7 +13,7 @@ type (
 	// for a Suback packet
 	SubackProperties struct {
 		ReasonString string
-		User         map[string]string
+		User         UserProperties
 	}
 )
 
@@ -23,7 +23,7 @@ func (s *Suback) Packet() *packets.Suback {
 	return &packets.Suback{
 		Reasons: s.Reasons,
 		Properties: &packets.Properties{
-			User: s.Properties.User,
+			User: s.Properties.User.ToPacketProperties(),
 		},
 	}
 }
@@ -35,7 +35,7 @@ func SubackFromPacketSuback(s *packets.Suback) *Suback {
 		Reasons: s.Reasons,
 		Properties: &SubackProperties{
 			ReasonString: s.Properties.ReasonString,
-			User:         s.Properties.User,
+			User:         UserPropertiesFromPacketUser(s.Properties.User),
 		},
 	}
 }

--- a/paho/cp_subscribe.go
+++ b/paho/cp_subscribe.go
@@ -22,7 +22,7 @@ type (
 // for a Subscribe packet
 type SubscribeProperties struct {
 	SubscriptionIdentifier *uint32
-	User                   map[string]string
+	User                   UserProperties
 }
 
 // InitProperties is a function that takes a packet library
@@ -31,7 +31,7 @@ type SubscribeProperties struct {
 func (s *Subscribe) InitProperties(prop *packets.Properties) {
 	s.Properties = &SubscribeProperties{
 		SubscriptionIdentifier: prop.SubscriptionIdentifier,
-		User:                   prop.User,
+		User:                   UserPropertiesFromPacketUser(prop.User),
 	}
 }
 
@@ -59,7 +59,7 @@ func (s *Subscribe) Packet() *packets.Subscribe {
 	if s.Properties != nil {
 		v.Properties = &packets.Properties{
 			SubscriptionIdentifier: s.Properties.SubscriptionIdentifier,
-			User:                   s.Properties.User,
+			User:                   s.Properties.User.ToPacketProperties(),
 		}
 	}
 

--- a/paho/cp_unsuback.go
+++ b/paho/cp_unsuback.go
@@ -13,7 +13,7 @@ type (
 	// for a Unsuback packet
 	UnsubackProperties struct {
 		ReasonString string
-		User         map[string]string
+		User         UserProperties
 	}
 )
 
@@ -23,7 +23,7 @@ func (u *Unsuback) Packet() *packets.Unsuback {
 	return &packets.Unsuback{
 		Reasons: u.Reasons,
 		Properties: &packets.Properties{
-			User: u.Properties.User,
+			User: u.Properties.User.ToPacketProperties(),
 		},
 	}
 }
@@ -35,7 +35,7 @@ func UnsubackFromPacketUnsuback(u *packets.Unsuback) *Unsuback {
 		Reasons: u.Reasons,
 		Properties: &UnsubackProperties{
 			ReasonString: u.Properties.ReasonString,
-			User:         u.Properties.User,
+			User:         UserPropertiesFromPacketUser(u.Properties.User),
 		},
 	}
 }

--- a/paho/cp_unsubscribe.go
+++ b/paho/cp_unsubscribe.go
@@ -12,7 +12,7 @@ type (
 	// UnsubscribeProperties is a struct of the properties that can be set
 	// for a Unsubscribe packet
 	UnsubscribeProperties struct {
-		User map[string]string
+		User UserProperties
 	}
 )
 
@@ -23,7 +23,7 @@ func (u *Unsubscribe) Packet() *packets.Unsubscribe {
 
 	if u.Properties != nil {
 		v.Properties = &packets.Properties{
-			User: u.Properties.User,
+			User: u.Properties.User.ToPacketProperties(),
 		}
 	}
 

--- a/paho/cp_utils.go
+++ b/paho/cp_utils.go
@@ -1,5 +1,74 @@
 package paho
 
+import "github.com/eclipse/paho.golang/packets"
+
+// UserProperty is a struct for the user provided values
+// permitted in the properties section
+type UserProperty struct {
+	Key, Value string
+}
+
+// UserProperties is a slice of UserProperty
+type UserProperties []UserProperty
+
+// Add is a helper function for easily adding a new user property
+func (u UserProperties) Add(key, value string) UserProperties {
+	u = append(u, UserProperty{key, value})
+
+	return u
+}
+
+// Get returns the first entry in the UserProperties that matches
+// key, or an empty string if the key is not found. Note that it is
+// permitted to have multiple entries with the same key, use GetAll
+// if it is expected to have multiple matches
+func (u UserProperties) Get(key string) string {
+	for _, v := range u {
+		if v.Key == key {
+			return v.Value
+		}
+	}
+
+	return ""
+}
+
+// GetAll returns a slice of all entries in the UserProperties
+// that match key, or a nil slice if none were found.
+func (u UserProperties) GetAll(key string) []string {
+	var ret []string
+	for _, v := range u {
+		if v.Key == key {
+			ret = append(ret, v.Value)
+		}
+	}
+
+	return ret
+}
+
+// ToPacketProperties converts a UserProperties to a slice
+// of packets.User which is used internally in the packets
+// library for user properties
+func (u UserProperties) ToPacketProperties() []packets.User {
+	ret := make([]packets.User, len(u))
+	for i, v := range u {
+		ret[i] = packets.User{v.Key, v.Value}
+	}
+
+	return ret
+}
+
+// UserPropertiesFromPacketUser converts a slice of packets.User
+// to an instance of UserProperties for easier consumption within
+// the client library
+func UserPropertiesFromPacketUser(up []packets.User) UserProperties {
+	ret := make(UserProperties, len(up))
+	for i, v := range up {
+		ret[i] = UserProperty{v.Key, v.Value}
+	}
+
+	return ret
+}
+
 // Byte is a helper function that take a byte and returns
 // a pointer to a byte of that value
 func Byte(b byte) *byte {

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -75,8 +75,8 @@ func (p *PingHandler) Start(c net.Conn, pt time.Duration) {
 			}
 			if time.Since(p.lastPing) >= pt {
 				//time to send a ping
+				p.debug.Println("pingHandler sending ping request")
 				if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(p.conn); err != nil {
-					p.debug.Println("pingHandler sending ping request")
 					if p.pingFailHandler != nil {
 						p.pingFailHandler(err)
 					}


### PR DESCRIPTION
It was pointed out that the key for user properties can be used
multiple times so a map was not the right solution, changed
to a slice of struct instead and modified the packet structs

fixes #21