### PR TITLE
Fix pinger lastPing && atomic

### DIFF
--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -75,13 +75,15 @@ func (p *PingHandler) Start(c net.Conn, pt time.Duration) {
 			}
 			if time.Since(p.lastPing) >= pt {
 				//time to send a ping
-				p.debug.Println("pingHandler sending ping request")
 				if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(p.conn); err != nil {
 					if p.pingFailHandler != nil {
 						p.pingFailHandler(err)
 					}
 					return
 				}
+				atomic.AddInt32(&p.pingOutstanding, 1)
+				p.lastPing = time.Now()
+				p.debug.Println("pingHandler sending ping request")
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: a-wing <1@233.email>

- Fix `lastPing` always is `0001-01-01 00:00:00 +0000 UTC`
- Fix  `atomic pingOutstanding` always is `0`

I think it is more reasonable to print the log after WriteTo conn