### PR TITLE
SubscriptionIdentifier should be a VBI

### DIFF
--- a/packets/properties.go
+++ b/packets/properties.go
@@ -67,7 +67,7 @@ type Properties struct {
 	CorrelationData []byte
 	// SubscriptionIdentifier is an identifier of the subscription to which
 	// the Publish matched
-	SubscriptionIdentifier *uint32
+	SubscriptionIdentifier *int
 	// SessionExpiryInterval is the time in seconds after a client disconnects
 	// that the server should retain the session information (subscriptions etc)
 	SessionExpiryInterval *uint32
@@ -182,7 +182,7 @@ func (i *Properties) Pack(p byte) []byte {
 	if p == PUBLISH || p == SUBSCRIBE {
 		if i.SubscriptionIdentifier != nil {
 			b.WriteByte(PropSubscriptionIdentifier)
-			writeUint32(*i.SubscriptionIdentifier, &b)
+			encodeVBIdirect(*i.SubscriptionIdentifier, &b)
 		}
 	}
 
@@ -350,7 +350,7 @@ func (i *Properties) PackBuf(p byte) *bytes.Buffer {
 	if p == PUBLISH || p == SUBSCRIBE {
 		if i.SubscriptionIdentifier != nil {
 			b.WriteByte(PropSubscriptionIdentifier)
-			writeUint32(*i.SubscriptionIdentifier, &b)
+			encodeVBIdirect(*i.SubscriptionIdentifier, &b)
 		}
 	}
 
@@ -532,7 +532,7 @@ func (i *Properties) Unpack(r *bytes.Buffer, p byte) error {
 			}
 			i.CorrelationData = cd
 		case PropSubscriptionIdentifier:
-			si, err := readUint32(buf)
+			si, err := decodeVBI(buf)
 			if err != nil {
 				return err
 			}

--- a/paho/cp_publish.go
+++ b/paho/cp_publish.go
@@ -25,7 +25,7 @@ type (
 		ResponseTopic          string
 		PayloadFormat          *byte
 		MessageExpiry          *uint32
-		SubscriptionIdentifier *uint32
+		SubscriptionIdentifier *int
 		TopicAlias             *uint16
 		User                   UserProperties
 	}

--- a/paho/cp_subscribe.go
+++ b/paho/cp_subscribe.go
@@ -21,7 +21,7 @@ type (
 // SubscribeProperties is a struct of the properties that can be set
 // for a Subscribe packet
 type SubscribeProperties struct {
-	SubscriptionIdentifier *uint32
+	SubscriptionIdentifier *int
 	User                   UserProperties
 }
 


### PR DESCRIPTION
Mistakenly had the sub id down as a uint32 rather than the variable
byte integer that the spec says, tbh I think the uint32 would have been
a better choice, vbis suck

closes #39