### PR TITLE
In-order routing and late ack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/eclipse/paho.golang
 go 1.15
 
 require (
+	github.com/google/go-cmp v0.5.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,16 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/packets/properties_test.go
+++ b/packets/properties_test.go
@@ -135,7 +135,7 @@ func TestPropertiess(t *testing.T) {
 	}
 }
 
-func TestInvalidPropertiess(t *testing.T) {
+func TestInvalidProperties(t *testing.T) {
 	if ValidateID(PUBLISH, PropRequestResponseInfo) {
 		t.Fatalf("'requestReplyInfo' is invalid for 'PUBLISH' packets")
 	}

--- a/paho/client.go
+++ b/paho/client.go
@@ -296,7 +296,6 @@ func (c *Client) routePublishPackets() {
 	for {
 		select {
 		case <-c.stop:
-			c.debug.Println("client stopping, routePublishPackets stopping")
 			return
 		case pb := <-c.publishPackets:
 			c.Router.Route(pb)

--- a/paho/client.go
+++ b/paho/client.go
@@ -297,7 +297,10 @@ func (c *Client) routePublishPackets() {
 		select {
 		case <-c.stop:
 			return
-		case pb := <-c.publishPackets:
+		case pb, open := <-c.publishPackets:
+			if !open {
+				return
+			}
 			c.Router.Route(pb)
 			switch pb.QoS {
 			case 1:

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -429,15 +430,17 @@ func TestClientReceiveAndAckInOrder(t *testing.T) {
 	wg.Wait()
 
 	require.Equal(t, expectedPublishPackets, actualPublishPackets)
-	require.Len(t, ts.receivedPubacks, 3)
-	require.Equal(t,
-		[]*packets.Puback{
-			{PacketID: 1, ReasonCode: 0, Properties: &packets.Properties{}},
-			{PacketID: 2, ReasonCode: 0, Properties: &packets.Properties{}},
-			{PacketID: 3, ReasonCode: 0, Properties: &packets.Properties{}},
-		},
-		ts.receivedPubacks,
-	)
+	require.Len(t, ts.ReceivedPubacks(), 3)
+	require.Eventually(t, func() bool {
+		return reflect.DeepEqual(
+			[]*packets.Puback{
+				{PacketID: 1, ReasonCode: 0, Properties: &packets.Properties{}},
+				{PacketID: 2, ReasonCode: 0, Properties: &packets.Properties{}},
+				{PacketID: 3, ReasonCode: 0, Properties: &packets.Properties{}},
+			},
+			ts.ReceivedPubacks(),
+		)
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestReceiveServerDisconnect(t *testing.T) {

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -2,8 +2,10 @@ package paho
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -99,6 +101,7 @@ func TestClientSubscribe(t *testing.T) {
 	c.SetDebugLogger(log.New(os.Stderr, "SUBSCRIBE: ", log.LstdFlags))
 
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -133,6 +136,7 @@ func TestClientUnsubscribe(t *testing.T) {
 	c.SetDebugLogger(log.New(os.Stderr, "UNSUBSCRIBE: ", log.LstdFlags))
 
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -164,6 +168,7 @@ func TestClientPublishQoS0(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -197,6 +202,7 @@ func TestClientPublishQoS1(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -235,6 +241,7 @@ func TestClientPublishQoS2(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -272,8 +279,10 @@ func TestClientReceiveQoS0(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
+	go c.routePublishPackets()
 
 	err := ts.SendPacket(&packets.Publish{
 		Topic:   "test/0",
@@ -306,8 +315,10 @@ func TestClientReceiveQoS1(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
+	go c.routePublishPackets()
 
 	err := ts.SendPacket(&packets.Publish{
 		Topic:   "test/1",
@@ -340,8 +351,10 @@ func TestClientReceiveQoS2(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
+	go c.routePublishPackets()
 
 	err := ts.SendPacket(&packets.Publish{
 		Topic:   "test/2",
@@ -351,6 +364,80 @@ func TestClientReceiveQoS2(t *testing.T) {
 	require.NoError(t, err)
 
 	<-rChan
+}
+
+func TestClientReceiveAndAckInOrder(t *testing.T) {
+	ts := newTestServer()
+	ts.SetResponse(packets.CONNACK, &packets.Connack{
+		ReasonCode:     0,
+		SessionPresent: false,
+		Properties: &packets.Properties{
+			MaximumPacketSize: Uint32(12345),
+			MaximumQOS:        Byte(1),
+			ReceiveMaximum:    Uint16(12345),
+			TopicAliasMaximum: Uint16(200),
+		},
+	})
+	go ts.Run()
+	defer ts.Stop()
+
+	var (
+		wg                   sync.WaitGroup
+		actualPublishPackets []packets.Publish
+		expectedPacketsCount = 3
+	)
+
+	wg.Add(expectedPacketsCount)
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+		Router: NewSingleHandlerRouter(func(p *Publish) {
+			defer wg.Done()
+			actualPublishPackets = append(actualPublishPackets, *p.Packet())
+		}),
+	})
+	require.NotNil(t, c)
+	c.SetDebugLogger(log.New(os.Stderr, "RECEIVEORDER: ", log.LstdFlags))
+	t.Cleanup(c.close)
+
+	ctx := context.Background()
+	ca, err := c.Connect(ctx, &Connect{
+		KeepAlive:  30,
+		ClientID:   "testClient",
+		CleanStart: true,
+		Properties: &ConnectProperties{
+			ReceiveMaximum: Uint16(200),
+		},
+	})
+	require.Nil(t, err)
+	assert.Equal(t, uint8(0), ca.ReasonCode)
+
+	var expectedPublishPackets []packets.Publish
+	for i := 1; i <= expectedPacketsCount; i++ {
+		p := packets.Publish{
+			PacketID: uint16(i),
+			Topic:    fmt.Sprintf("test/%d", i),
+			Payload:  []byte(fmt.Sprintf("test payload %d", i)),
+			QoS:      1,
+			Properties: &packets.Properties{
+				User: make([]packets.User, 0),
+			},
+		}
+		expectedPublishPackets = append(expectedPublishPackets, p)
+		require.NoError(t, ts.SendPacket(&p))
+	}
+
+	wg.Wait()
+
+	require.Equal(t, expectedPublishPackets, actualPublishPackets)
+	require.Len(t, ts.receivedPubacks, 3)
+	require.Equal(t,
+		[]*packets.Puback{
+			{PacketID: 1, ReasonCode: 0, Properties: &packets.Properties{}},
+			{PacketID: 2, ReasonCode: 0, Properties: &packets.Properties{}},
+			{PacketID: 3, ReasonCode: 0, Properties: &packets.Properties{}},
+		},
+		ts.receivedPubacks,
+	)
 }
 
 func TestReceiveServerDisconnect(t *testing.T) {
@@ -373,6 +460,7 @@ func TestReceiveServerDisconnect(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -405,6 +493,7 @@ func TestAuthenticate(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10000)
 	c.clientInflight = semaphore.NewWeighted(10000)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -441,7 +441,7 @@ func TestClientReceiveAndAckInOrder(t *testing.T) {
 		},
 		time.Second,
 		10*time.Millisecond,
-		cmp.Diff(expectedAcks, ts.receivedPubacks),
+		cmp.Diff(expectedAcks, ts.ReceivedPubacks()),
 	)
 }
 

--- a/paho/cp_publish.go
+++ b/paho/cp_publish.go
@@ -8,8 +8,9 @@ import (
 )
 
 type (
-	// Publish is a reporesentation of the MQTT Publish packet
+	// Publish is a representation of the MQTT Publish packet
 	Publish struct {
+		PacketID   uint16
 		QoS        byte
 		Retain     bool
 		Topic      string
@@ -51,10 +52,11 @@ func (p *Publish) InitProperties(prop *packets.Properties) {
 // returns a paho library Publish
 func PublishFromPacketPublish(p *packets.Publish) *Publish {
 	v := &Publish{
-		QoS:     p.QoS,
-		Retain:  p.Retain,
-		Topic:   p.Topic,
-		Payload: p.Payload,
+		PacketID: p.PacketID,
+		QoS:      p.QoS,
+		Retain:   p.Retain,
+		Topic:    p.Topic,
+		Payload:  p.Payload,
 	}
 	v.InitProperties(p.Properties)
 
@@ -65,10 +67,11 @@ func PublishFromPacketPublish(p *packets.Publish) *Publish {
 // on which it is called
 func (p *Publish) Packet() *packets.Publish {
 	v := &packets.Publish{
-		QoS:     p.QoS,
-		Retain:  p.Retain,
-		Topic:   p.Topic,
-		Payload: p.Payload,
+		PacketID: p.PacketID,
+		QoS:      p.QoS,
+		Retain:   p.Retain,
+		Topic:    p.Topic,
+		Payload:  p.Payload,
 	}
 	if p.Properties != nil {
 		v.Properties = &packets.Properties{

--- a/paho/message_ids_test.go
+++ b/paho/message_ids_test.go
@@ -30,6 +30,7 @@ func TestMidNoExhaustion(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10)
 	c.clientInflight = semaphore.NewWeighted(10)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	go c.Incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
@@ -57,6 +58,7 @@ func TestMidExhaustion(t *testing.T) {
 	c.serverInflight = semaphore.NewWeighted(10)
 	c.clientInflight = semaphore.NewWeighted(10)
 	c.stop = make(chan struct{})
+	c.publishPackets = make(chan *packets.Publish)
 	c.SetDebugLogger(log.New(os.Stderr, "PUBLISHQOS1: ", log.LstdFlags))
 
 	cp := &CPContext{}

--- a/paho/router.go
+++ b/paho/router.go
@@ -100,7 +100,7 @@ func (r *StandardRouter) Route(pb *packets.Publish) {
 	}
 }
 
-// SetDebug sets the logger l to be used for printing debug
+// SetDebugLogger sets the logger l to be used for printing debug
 // information for the router
 func (r *StandardRouter) SetDebugLogger(l Logger) {
 	r.debug = l
@@ -205,7 +205,7 @@ func (s *SingleHandlerRouter) Route(pb *packets.Publish) {
 	s.handler(m)
 }
 
-// SetDebug sets the logger l to be used for printing debug
+// SetDebugLogger sets the logger l to be used for printing debug
 // information for the router
 func (s *SingleHandlerRouter) SetDebugLogger(l Logger) {
 	s.debug = l

--- a/paho/server_test.go
+++ b/paho/server_test.go
@@ -171,20 +171,20 @@ func (t *testServer) Run() {
 
 func (t *testServer) ReceivedPubacks() []packets.Puback {
 	t.receivedMu.Lock()
-	defer t.receivedMu.Lock()
+	defer t.receivedMu.Unlock()
 	packets := make([]packets.Puback, len(t.receivedPubacks))
-	for k, v := range t.receivedPubacks {
-		packets[k] = *v
+	for k := range t.receivedPubacks {
+		packets[k] = *t.receivedPubacks[k]
 	}
 	return packets
 }
 
 func (t *testServer) ReceivedPubrecs() []packets.Pubrec {
 	t.receivedMu.Lock()
-	defer t.receivedMu.Lock()
+	defer t.receivedMu.Unlock()
 	packets := make([]packets.Pubrec, len(t.receivedPubrecs))
-	for k, v := range t.receivedPubrecs {
-		packets[k] = *v
+	for k := range t.receivedPubrecs {
+		packets[k] = *t.receivedPubrecs[k]
 	}
 	return packets
 }


### PR DESCRIPTION
Sorry for not creating an issue first but I developed this for the company I work for so I'm creating a draft PR to test the waters. I think it may be more useful to discuss this with the code changes at hand. If it doesn't work for you I can still open an issue first, please let me know.

This PR aims to solve two issues:
1. Message ordering: https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901240
2. Message acknowledgment only after the message processing has completed to ensure re-delivery of "unacked" messages from the server in case of abnormal client termination

In order to avoid blocking the `Incoming()` loop (which would lead to unexpected behaviours such as client disconnections etc...) you are routing the `PUBLISH` packets asynchronously (i.e. by creating a `go` routine: `go c.Router.Route(pb)`). Thus a `go` routine is created for each `PUBLISH` packet, which changes the order of the messages as received from the server. See example in the [Go Playground](https://play.golang.org/p/7ihnnxm7WT7).

The solution I'm proposing is to queue the `PUBLISH` packets in the same order as they are being received in a buffered channel of the size of the "receive maximum" (worst case the buffer size would be `65535`).

We then create a new worker in `Connect()` that listens to the new buffered channel and calls the router without creating a `go` routine. It is up to the user to create a routine in their message handler if they don't want to block. This way the client would give users maximum flexibility when building routers (blocking vs non-blocking APIs).

Since the call to the router in this PR is blocking we can now make sure that the `PUBACK` is sent to the server only after the message handler is done with the message. In case of abnormal termination of the client the `PUBACK` won't be sent to the server which will redeliver the related `PUBLISH` packet (according to "clean start" and "session expiry interval" settings).

This has been tested with running instances of VerneMQ with these settings:
* 10 producers publishing 100k messages each (concurrently)
* a single consumer with receive maximum 65535 and session expiry interval 0xffffffff

The consumer is clearly swamped with messages but given the "receive maximum" setting it receives only 65535 `PUBLISH` packets which fit perfectly in the buffered channel so the `Incoming()` loop is never blocked.

**Testing**

I'm not sure about test coverage here, I'd write an integration test with a real broker running but it doesn't look like you have support for integration tests in this project. Do you think an additional unit test could be useful here? Any pointers?