### PR TITLE
Deadlock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+test:
+	go test -race ./packets/ -v -count 1
+	go test -race ./paho/ -v -count 1

--- a/paho/client.go
+++ b/paho/client.go
@@ -778,10 +778,11 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish) (*Publis
 func (c *Client) Disconnect(d *Disconnect) error {
 	c.debug.Println("disconnecting")
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	defer func() { _ = c.Conn.Close() }()
-
 	_, err := d.Packet().WriteTo(c.Conn)
+	c.mu.Unlock()
+
+	c.close()
+	c.workers.Wait() // wait anyway in case close was already called
 
 	return err
 }

--- a/paho/client.go
+++ b/paho/client.go
@@ -501,9 +501,9 @@ func (c *Client) Authenticate(ctx context.Context, a *Auth) (*AuthResponse, erro
 	var rp packets.ControlPacket
 	select {
 	case <-ctx.Done():
-		if e := ctx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for Auth to complete")
-			return nil, e
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case rp = <-c.raCtx.Return:
 	}
@@ -568,9 +568,9 @@ func (c *Client) Subscribe(ctx context.Context, s *Subscribe) (*Suback, error) {
 
 	select {
 	case <-subCtx.Done():
-		if e := subCtx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for SUBACK")
-			return nil, e
+		if ctxErr := subCtx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case sap = <-cpCtx.Return:
 	}
@@ -631,9 +631,9 @@ func (c *Client) Unsubscribe(ctx context.Context, u *Unsubscribe) (*Unsuback, er
 
 	select {
 	case <-unsubCtx.Done():
-		if e := unsubCtx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for UNSUBACK")
-			return nil, e
+		if ctxErr := unsubCtx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case uap = <-cpCtx.Return:
 	}
@@ -731,9 +731,9 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish) (*Publis
 
 	select {
 	case <-pubCtx.Done():
-		if e := pubCtx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for Publish response")
-			return nil, e
+		if ctxErr := pubCtx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case resp = <-cpCtx.Return:
 	}


### PR DESCRIPTION
This PR is to address the deadlock on cleanups, see [here](https://github.com/eclipse/paho.golang/issues/54).

It also addresses another bug that I found related to canceled contexts. It was causing panics due to the usual nil pointer dereference (e.g. `cap *packets.Connack` was passed as `nil` [here](https://github.com/eclipse/paho.golang/blob/6f81099163c2cbbe7862b98e28062baca74cd275/paho/client.go#L244) causing the `panic`).

To fix the deadlocks I'm proposing an idempotent `close()`. This way we don't have to worry about calling it multiple times from different places. Once called the method checks whether it was being closed already or not.

Even though not all calls to `close()` are blocking ones due to this approach, the code should still offer a blocking API to the user considering how intertwined are the methods. `close()` is unexported and always called by a more important method which  actually blocks.

I added a test to verify the correct cleanup behaviour and to test the context cancelation.

**Note:** I hope you don't mind the Makefile, I added a recipe to always run the tests with the race enabled.

Fixes: https://github.com/eclipse/paho.golang/issues/54