### PR TITLE
Deadlock + minor bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+test:
+	go test -race ./packets/ -v -count 1
+	go test -race ./paho/ -v -count 1

--- a/paho/client.go
+++ b/paho/client.go
@@ -778,10 +778,11 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish) (*Publis
 func (c *Client) Disconnect(d *Disconnect) error {
 	c.debug.Println("disconnecting")
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	defer func() { _ = c.Conn.Close() }()
-
 	_, err := d.Packet().WriteTo(c.Conn)
+	c.mu.Unlock()
+
+	c.close()
+	c.workers.Wait() // wait anyway in case close was already called
 
 	return err
 }

--- a/paho/client.go
+++ b/paho/client.go
@@ -49,9 +49,7 @@ type (
 	Client struct {
 		mu sync.Mutex
 		ClientConfig
-		// caCtx is used for synchronously handling the connect/connack
-		// flow, raCtx is used for handling the MQTTv5 authentication
-		// exchange.
+		// raCtx is used for handling the MQTTv5 authentication exchange.
 		raCtx          *CPContext
 		stop           chan struct{}
 		publishPackets chan *packets.Publish

--- a/paho/client.go
+++ b/paho/client.go
@@ -501,9 +501,9 @@ func (c *Client) Authenticate(ctx context.Context, a *Auth) (*AuthResponse, erro
 	var rp packets.ControlPacket
 	select {
 	case <-ctx.Done():
-		if e := ctx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for Auth to complete")
-			return nil, e
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case rp = <-c.raCtx.Return:
 	}
@@ -568,9 +568,9 @@ func (c *Client) Subscribe(ctx context.Context, s *Subscribe) (*Suback, error) {
 
 	select {
 	case <-subCtx.Done():
-		if e := subCtx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for SUBACK")
-			return nil, e
+		if ctxErr := subCtx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case sap = <-cpCtx.Return:
 	}
@@ -631,9 +631,9 @@ func (c *Client) Unsubscribe(ctx context.Context, u *Unsubscribe) (*Unsuback, er
 
 	select {
 	case <-unsubCtx.Done():
-		if e := unsubCtx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for UNSUBACK")
-			return nil, e
+		if ctxErr := unsubCtx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case uap = <-cpCtx.Return:
 	}
@@ -731,9 +731,9 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish) (*Publis
 
 	select {
 	case <-pubCtx.Done():
-		if e := pubCtx.Err(); e == context.DeadlineExceeded {
-			c.debug.Println("timeout waiting for Publish response")
-			return nil, e
+		if ctxErr := pubCtx.Err(); ctxErr != nil {
+			c.debug.Println(fmt.Sprintf("terminated due to context: %v", ctxErr))
+			return nil, ctxErr
 		}
 	case resp = <-cpCtx.Return:
 	}

--- a/paho/message_ids_test.go
+++ b/paho/message_ids_test.go
@@ -31,7 +31,7 @@ func TestMidNoExhaustion(t *testing.T) {
 	c.clientInflight = semaphore.NewWeighted(10)
 	c.stop = make(chan struct{})
 	c.publishPackets = make(chan *packets.Publish)
-	go c.Incoming()
+	go c.incoming()
 	go c.PingHandler.Start(c.Conn, 30*time.Second)
 
 	for i := 0; i < 70000; i++ {


### PR DESCRIPTION
This PR is to address the deadlock on cleanups, see [here](https://github.com/eclipse/paho.golang/issues/54).

It also addresses another bug that I found related to canceled contexts. It was causing panics due to the usual nil pointer dereference (e.g. `cap *packets.Connack` was passed as `nil` [here](https://github.com/eclipse/paho.golang/blob/6f81099163c2cbbe7862b98e28062baca74cd275/paho/client.go#L244) causing the `panic`).

### Changes
* wait for `CONNACK` without starting `incoming` worker
  * this helped with the removal of the deadlock
* handle all context errors
* move all workers at the end of `Connect` when all operations have completed successfully
* making `incoming` and `error` methods unexported
  * this helped me restrict the context where the lock could be acquired by the user calling a method directly (e.g. `Authenticate`, `Connect`...)
  * it makes more clear that the user isn't supposed to call those methods
  * the methods can still be called internally in tests
*  new `TestCleanup` to test for other context errors (e.g. canceled context) and to test for the deadlock
   * I wrote the test before making the changes and it was indeed locking forever. once I could replicate the deadlock I worked on the fix I'm proposing with this PR
* new `TestDisconnect` which tests that `Disconnect()` doesn't lock and that it's also possible to disconnect multiple times without locking
* new `TestCloseDeadlock` which calls `close()` and `Disconnect` concurrently multiple times to see if a deadlock occurs
* `Makefile` with recipe to automate execution of all tests (with the `-race` flag)

Fixes: https://github.com/eclipse/paho.golang/issues/54