### PR TITLE
Manual acknowledgments

### DIFF
--- a/packets/publish.go
+++ b/packets/publish.go
@@ -50,7 +50,7 @@ func (p *Publish) Buffers() net.Buffers {
 	var b bytes.Buffer
 	writeString(p.Topic, &b)
 	if p.QoS > 0 {
-		writeUint16(p.PacketID, &b)
+		_ = writeUint16(p.PacketID, &b)
 	}
 	idvp := p.Properties.Pack(PUBLISH)
 	encodeVBIdirect(len(idvp), &b)

--- a/paho/acks_tracker.go
+++ b/paho/acks_tracker.go
@@ -1,0 +1,79 @@
+package paho
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/eclipse/paho.golang/packets"
+)
+
+var (
+	ErrPacketNotFound = errors.New("packet not found")
+)
+
+type acksTracker struct {
+	mx    sync.Mutex
+	order []packet
+}
+
+func (t *acksTracker) add(pb *packets.Publish) {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	for _, v := range t.order {
+		if v.pb.PacketID == pb.PacketID {
+			return // already added
+		}
+	}
+
+	t.order = append(t.order, packet{pb: pb})
+}
+
+func (t *acksTracker) markAsAcked(pb *packets.Publish) error {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	for k, v := range t.order {
+		if pb.PacketID == v.pb.PacketID {
+			t.order[k].acknowledged = true
+			return nil
+		}
+	}
+
+	return ErrPacketNotFound
+}
+
+func (t *acksTracker) flush(do func([]*packets.Publish)) {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+
+	var (
+		buf []*packets.Publish
+	)
+	for _, v := range t.order {
+		if v.acknowledged {
+			buf = append(buf, v.pb)
+		} else {
+			break
+		}
+	}
+
+	if len(buf) == 0 {
+		return
+	}
+
+	do(buf)
+	t.order = t.order[len(buf):]
+}
+
+// reset should be used upon disconnections
+func (t *acksTracker) reset() {
+	t.mx.Lock()
+	defer t.mx.Unlock()
+	t.order = nil
+}
+
+type packet struct {
+	pb           *packets.Publish
+	acknowledged bool
+}

--- a/paho/acks_tracker_test.go
+++ b/paho/acks_tracker_test.go
@@ -17,6 +17,12 @@ func TestAcksTracker(t *testing.T) {
 		p4 = &packets.Publish{PacketID: 4} // to test not found
 	)
 
+	t.Run("flush-empty", func(t *testing.T) {
+		at.flush(func(_ []*packets.Publish) {
+			t.Fatal("flush should not call 'do' since no packets have been added nor acknowledged")
+		})
+	})
+
 	t.Run("flush-without-acking", func(t *testing.T) {
 		at.add(p1)
 		at.add(p2)
@@ -73,7 +79,7 @@ func TestAcksTracker(t *testing.T) {
 
 	t.Run("flush-after-acking-everything", func(t *testing.T) {
 		at.flush(func(_ []*packets.Publish) {
-			t.Fatal("no call to 'do' expected, we flushed all packets")
+			t.Fatal("no call to 'do' expected, we flushed all packets already")
 		})
 	})
 }

--- a/paho/acks_tracker_test.go
+++ b/paho/acks_tracker_test.go
@@ -1,0 +1,79 @@
+package paho
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/eclipse/paho.golang/packets"
+)
+
+func TestAcksTracker(t *testing.T) {
+	var (
+		at acksTracker
+		p1 = &packets.Publish{PacketID: 1}
+		p2 = &packets.Publish{PacketID: 2}
+		p3 = &packets.Publish{PacketID: 3}
+		p4 = &packets.Publish{PacketID: 4} // to test not found
+	)
+
+	t.Run("flush-without-acking", func(t *testing.T) {
+		at.add(p1)
+		at.add(p2)
+		at.add(p3)
+		require.Equal(t, ErrPacketNotFound, at.markAsAcked(p4))
+		at.flush(func(_ []*packets.Publish) {
+			t.Fatal("flush should not call 'do' since no packets have been acknowledged so far")
+		})
+	})
+
+	t.Run("ack-in-the-middle", func(t *testing.T) {
+		require.NoError(t, at.markAsAcked(p3))
+		at.flush(func(_ []*packets.Publish) {
+			t.Fatal("flush should not call 'do' since p1 and p2 have not been acknowledged yet")
+		})
+	})
+
+	t.Run("idempotent-acking", func(t *testing.T) {
+		require.NoError(t, at.markAsAcked(p3))
+		require.NoError(t, at.markAsAcked(p3))
+		require.NoError(t, at.markAsAcked(p3))
+	})
+
+	t.Run("ack-first", func(t *testing.T) {
+		var flushCalled bool
+		require.NoError(t, at.markAsAcked(p1))
+		at.flush(func(pbs []*packets.Publish) {
+			require.Equal(t, []*packets.Publish{p1}, pbs, "Only p1 expected even though p3 was acked, p2 is still missing")
+			flushCalled = true
+		})
+		require.True(t, flushCalled)
+	})
+
+	t.Run("ack-after-flush", func(t *testing.T) {
+		var flushCalled bool
+		require.NoError(t, at.markAsAcked(p2))
+		at.add(p4) // this should just be appended and not flushed (yet)
+		at.flush(func(pbs []*packets.Publish) {
+			require.Equal(t, []*packets.Publish{p2, p3}, pbs, "Only p2 and p3 expected, p1 was flushed in the previous call")
+			flushCalled = true
+		})
+		require.True(t, flushCalled)
+	})
+
+	t.Run("ack-last", func(t *testing.T) {
+		var flushCalled bool
+		require.NoError(t, at.markAsAcked(p4))
+		at.flush(func(pbs []*packets.Publish) {
+			require.Equal(t, []*packets.Publish{p4}, pbs, "Only p4 expected, the rest was flushed in previous calls")
+			flushCalled = true
+		})
+		require.True(t, flushCalled)
+	})
+
+	t.Run("flush-after-acking-everything", func(t *testing.T) {
+		at.flush(func(_ []*packets.Publish) {
+			t.Fatal("no call to 'do' expected, we flushed all packets")
+		})
+	})
+}

--- a/paho/client.go
+++ b/paho/client.go
@@ -59,7 +59,7 @@ type (
 		// are acknowledged.
 		EnableManualAcknowledgment bool
 		// SendAcksInterval is used only when EnableManualAcknowledgment is true
-		// it determines how often the client tries to send a batch of acknowledgments in the right order
+		// it determines how often the client tries to send a batch of acknowledgments in the right order to the server.
 		SendAcksInterval time.Duration
 	}
 	// Client is the struct representing an MQTT client
@@ -306,7 +306,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 
 		c.acksTracker.reset()
 		sendAcksInterval := defaultSendAckInterval
-		if c.SendAcksInterval != 0 {
+		if c.SendAcksInterval > 0 {
 			sendAcksInterval = c.SendAcksInterval
 		}
 

--- a/paho/client.go
+++ b/paho/client.go
@@ -399,10 +399,10 @@ func (c *Client) routePublishPackets() {
 // Disconnect, the Stop channel is closed or there is an error reading
 // a packet from the network connection
 func (c *Client) incoming() {
+	defer c.debug.Println("client stopping, incoming stopping")
 	for {
 		select {
 		case <-c.stop:
-			c.debug.Println("client stopping, incoming stopping")
 			return
 		default:
 			recv, err := packets.ReadPacket(c.Conn)
@@ -436,7 +436,15 @@ func (c *Client) incoming() {
 			case packets.PUBLISH:
 				pb := recv.Content.(*packets.Publish)
 				c.debug.Printf("received QoS%d PUBLISH", pb.QoS)
-				c.publishPackets <- pb
+				c.mu.Lock()
+				select {
+				case <-c.stop:
+					c.mu.Unlock()
+					return
+				default:
+					c.publishPackets <- pb
+					c.mu.Unlock()
+				}
 			case packets.PUBACK, packets.PUBCOMP, packets.SUBACK, packets.UNSUBACK:
 				c.debug.Printf("received %s packet with id %d", recv.PacketType(), recv.PacketID())
 				if cpCtx := c.MIDs.Get(recv.PacketID()); cpCtx != nil {
@@ -550,12 +558,18 @@ func (c *Client) error(e error) {
 // is received.
 func (c *Client) Authenticate(ctx context.Context, a *Auth) (*AuthResponse, error) {
 	c.debug.Println("client initiated reauthentication")
-	c.mu.Lock()
-	defer c.mu.Unlock()
 
+	c.mu.Lock()
+	if c.raCtx != nil {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("previous authentication is still in progress")
+	}
 	c.raCtx = &CPContext{ctx, make(chan packets.ControlPacket, 1)}
+	c.mu.Unlock()
 	defer func() {
+		c.mu.Lock()
 		c.raCtx = nil
+		c.mu.Unlock()
 	}()
 
 	c.debug.Println("sending AUTH")

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -750,6 +750,63 @@ func TestCloseDeadlock(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSendOnClosedChannel(t *testing.T) {
+	ts := newTestServer()
+	ts.SetResponse(packets.CONNACK, &packets.Connack{
+		ReasonCode:     0,
+		SessionPresent: false,
+		Properties: &packets.Properties{
+			MaximumPacketSize: Uint32(12345),
+			MaximumQOS:        Byte(1),
+			ReceiveMaximum:    Uint16(12345),
+			TopicAliasMaximum: Uint16(200),
+		},
+	})
+	go ts.Run()
+	defer ts.Stop()
+
+	c := NewClient(ClientConfig{
+		Conn: ts.ClientConn(),
+	})
+	require.NotNil(t, c)
+
+	if testing.Verbose() {
+		l := log.New(os.Stdout, t.Name(), log.LstdFlags)
+		c.SetDebugLogger(l)
+		c.SetErrorLogger(l)
+	}
+
+	ctx := context.Background()
+	ca, err := c.Connect(ctx, &Connect{
+		KeepAlive:  30,
+		ClientID:   "testClient",
+		CleanStart: true,
+		Properties: &ConnectProperties{
+			ReceiveMaximum: Uint16(200),
+		},
+	})
+	require.Nil(t, err)
+	assert.Equal(t, uint8(0), ca.ReasonCode)
+
+	go func() {
+		for i := uint16(0); true; i++ {
+			err := ts.SendPacket(&packets.Publish{
+				Payload:  []byte("ciao"),
+				Topic:    "test",
+				PacketID: i,
+				QoS:      1,
+			})
+			if err != nil {
+				t.Logf("Send packet error: %v", err)
+				return
+			}
+		}
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	c.close()
+}
+
 func isChannelClosed(ch chan struct{}) (closed bool) {
 	defer func() {
 		err, ok := recover().(error)


### PR DESCRIPTION
This PR is to address this issue: https://github.com/eclipse/paho.golang/issues/53

We want the ability to manually control the PUBACK/PUBREC transmission in order to avoid message loss.

The idea is to acknowledge a message only after it has been processed successfully by a client.

### Changes
* the default behaviour is not changed, acks will be sent in order automatically by the client, right after routing
* if the users want to manually enable acknowledgments they just have to set `EnableManualAcknowledgment` to `true` and then call `Ack()` in any order. the client will take care of sending the acks to the server back in right order.
  * this is something I've seen implemented in other MQTT clients (e.g. HiveMQ Java client)
* a background routine will periodically try to flush the acks in order, by acquiring a lock, as often as configured via the `SendAcksInterval` attribute

### Sidenotes
* this code has been running for several days with a few clients in our staging environment with no issues (with manual acks enabled)
* we're planning to go live in production with this branch in 1-2 weeks here at [Netdata](https://github.com/netdata/netdata) which should give us a certain degree of certainty that it works and performs well. of course we'll keep monitoring it afterwards as well.