### PR TITLE
Add websocket support to AutoPaho

### DIFF
--- a/autopaho/examples/docker/binds/mosquitto/config/mosquitto.conf
+++ b/autopaho/examples/docker/binds/mosquitto/config/mosquitto.conf
@@ -10,6 +10,9 @@ allow_anonymous true # Anyone can connect
 # Mosquitto v2+ requires that a listener be defined (otherwise it listens on loopback)
 listener 1883
 
+# Also allow websocket connections over port 80
+listener 80
+protocol websockets
 
 #log_type error
 #log_type warning

--- a/autopaho/examples/docker/docker-compose.yml
+++ b/autopaho/examples/docker/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       context: ../../../
       dockerfile: autopaho/examples/docker/subscriber/dockerfile
     environment:
-      subdemo_serverURL: tcp://mosquitto:1883
+      subdemo_serverURL: ws://mosquitto:80
       subdemo_clientID: mqtt_subscriber
       subdemo_topic: topic1
       subdemo_qos: 1

--- a/autopaho/examples/docker/readme.md
+++ b/autopaho/examples/docker/readme.md
@@ -9,6 +9,9 @@ Because the publisher (`pub`), broker (`mosquitto`) and subscriber (`sub`) run i
 simulates a real deployment. One thing to bear in mind is that the network between the containers is very fast and
 reliable (but there are some techniques that can be used to simulate failures etc).
 
+The subscriber connects via websockets whereas the publisher uses a TCP connection (this is set via environmental
+variables).
+
 Note: The docker-compose file sets the context to the root of paho.golang; this is done to avoid the need for 
 publisher and subscriber to be in their own modules. This avoids the need to import `paho.golang` (which would 
 make using this for testing changes to `autopaho` difficult because go would fetch the package from git).

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/google/go-cmp v0.5.5
+	github.com/gorilla/websocket v1.4.2
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Add support for websocket connections to AutoPaho. The docker example has been updated to make use of this.

Ref Issue: #61 
