### PR TITLE
autopaho: set connect packet parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: test
-test:
+.PHONY: test unittest
+
+unittest:
+	go test -race -tags=unittest ./autopaho/ -v -count 1
+
+test: unittest
 	go test -race ./packets/ -v -count 1
 	go test -race ./paho/ -v -count 1
+	

--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -81,11 +81,14 @@ type ConnectionManager struct {
 	done chan struct{} // Channel that will be closed when the process has cleanly shutdown
 }
 
+// ResetUsernamePassword clears any configured username and password on the client configuration
 func (cfg *ClientConfig) ResetUsernamePassword() {
 	cfg.connectPassword = []byte{}
 	cfg.connectUsername = ""
 }
 
+// SetUsernamePassword configures username and password properties for the Connect packets
+// These values are staged in the ClientConfig, and preparation of the Connect packet is deferred.
 func (cfg *ClientConfig) SetUsernamePassword(username string, password []byte) {
 	if len(username) > 0 {
 		cfg.connectUsername = username
@@ -96,6 +99,8 @@ func (cfg *ClientConfig) SetUsernamePassword(username string, password []byte) {
 	}
 }
 
+// SetWillMessage configures the Will topic, payload, QOS and Retain facets of the client connection
+// These values are staged in the ClientConfig, for later preparation of the Connect packet.
 func (cfg *ClientConfig) SetWillMessage(topic string, payload []byte, qos byte, retain bool) {
 	cfg.willTopic = topic
 	cfg.willPayload = payload
@@ -103,11 +108,15 @@ func (cfg *ClientConfig) SetWillMessage(topic string, payload []byte, qos byte, 
 	cfg.willRetain = retain
 }
 
+// SetConnectPacketConfigurator assigns a callback for modification of the Connect packet, called before the connection is opened, allowing the application to adjust its configuration before establishing a connection.
+// This function should be treated as asynchronous, and expected to have no side effects.
 func (cfg *ClientConfig) SetConnectPacketConfigurator(fn func(*paho.Connect) *paho.Connect) bool {
 	cfg.connectPacketBuilder = fn
 	return fn != nil
 }
 
+// buildConnectPacket constructs a Connect packet for the paho client, based on staged configuration.
+// If the program uses SetConnectPacketConfigurator, the provided callback will be executed with the preliminary Connect packet representation.
 func (cfg *ClientConfig) buildConnectPacket() *paho.Connect {
 
 	cp := &paho.Connect{

--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -96,6 +96,13 @@ func (cfg *ClientConfig) SetUsernamePassword(username string, password []byte) {
 	}
 }
 
+func (cfg *ClientConfig) SetWillMessage(topic string, payload []byte, qos byte, retain bool) {
+	cfg.willTopic = topic
+	cfg.willPayload = payload
+	cfg.willQos = qos
+	cfg.willRetain = retain
+}
+
 func (cfg *ClientConfig) SetConnectPacketConfigurator(fn func(*paho.Connect) *paho.Connect) bool {
 	cfg.connectPacketBuilder = fn
 	return fn != nil

--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -1,0 +1,94 @@
+// build +unittest
+
+package autopaho
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.golang/paho"
+)
+
+func TestClientConfig_buildConnectPacket(t *testing.T) {
+	broker, _ := url.Parse("tcp://127.0.0.1:1883")
+
+	config := ClientConfig{
+		BrokerUrls:        []*url.URL{broker},
+		KeepAlive:         5,
+		ConnectRetryDelay: 5 * time.Second,
+		ConnectTimeout:    5 * time.Second,
+
+		// extends the lower-level paho.ClientConfig
+		ClientConfig: paho.ClientConfig{
+			ClientID: "test",
+		},
+	}
+
+	// Validate initial state
+	cp := config.buildConnectPacket()
+
+	if cp.WillMessage != nil {
+		t.Errorf("Expected empty Will message, got: %v", cp.WillMessage)
+	}
+
+	if cp.UsernameFlag != false || cp.Username != "" {
+		t.Errorf("Expected absent/empty username, got: flag=%v username=%v", cp.UsernameFlag, cp.Username)
+	}
+
+	if cp.PasswordFlag != false || len(cp.Password) > 0 {
+		t.Errorf("Expected absent/empty password, got: flag=%v password=%v", cp.PasswordFlag, cp.Password)
+	}
+
+	// Set some common parameters
+	config.SetUsernamePassword("testuser", []byte("testpassword"))
+	config.SetWillMessage(fmt.Sprintf("client/%s/state", config.ClientID), []byte("disconnected"), 1, true)
+
+	cp = config.buildConnectPacket()
+
+	if cp.UsernameFlag == false || cp.Username != "testuser" {
+		t.Errorf("Expected a username, got: flag=%v username=%v", cp.UsernameFlag, cp.Username)
+	}
+
+	pmatch := bytes.Compare(cp.Password, []byte("testpassword"))
+
+	if cp.PasswordFlag == false || len(cp.Password) == 0 || pmatch != 0 {
+		t.Errorf("Expected a password, got: flag=%v password=%v", cp.PasswordFlag, cp.Password)
+	}
+
+	if cp.WillMessage == nil {
+		t.Error("Expected a Will message, found nil")
+	}
+
+	if cp.WillMessage.Topic != "client/test/state" {
+		t.Errorf("Will message topic did not match expected [%v], found [%v]", "client/test/state", cp.WillMessage.Topic)
+	}
+
+	if cp.WillMessage.QoS != byte(1) {
+		t.Errorf("Wlll message QOS did not match expected [1]: found [%v]", cp.WillMessage.QoS)
+	}
+
+	if cp.WillMessage.Retain != true {
+		t.Errorf("Will message Retain did not match expected [true]: found [%v]", cp.WillMessage.Retain)
+	}
+
+	if *(cp.WillProperties.WillDelayInterval) != 10 { // assumes default 2x keep alive
+		t.Errorf("Will message Delay Interval did not match expected [10]: found [%v]", *(cp.Properties.WillDelayInterval))
+	}
+
+	// Set an override method for the connect packet
+	config.SetConnectPacketConfigurator(func(c *paho.Connect) *paho.Connect {
+		delay := uint32(200)
+		c.WillProperties.WillDelayInterval = &delay
+		return c
+	})
+
+	cp = config.buildConnectPacket()
+
+	if *(cp.WillProperties.WillDelayInterval) != 200 { // verifies the override
+		t.Errorf("Will message Delay Interval did not match expected [200]: found [%v]", *(cp.Properties.WillDelayInterval))
+	}
+
+}

--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -67,7 +67,7 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 	}
 
 	if cp.WillMessage.QoS != byte(1) {
-		t.Errorf("Wlll message QOS did not match expected [1]: found [%v]", cp.WillMessage.QoS)
+		t.Errorf("Will message QOS did not match expected [1]: found [%v]", cp.WillMessage.QoS)
 	}
 
 	if cp.WillMessage.Retain != true {

--- a/autopaho/net.go
+++ b/autopaho/net.go
@@ -46,11 +46,7 @@ func establishBrokerConnection(ctx context.Context, cfg ClientConfig) (*paho.Cli
 
 			if err == nil {
 				cli := paho.NewClient(cfg.ClientConfig)
-				cp := &paho.Connect{
-					KeepAlive:  cfg.KeepAlive,
-					ClientID:   cfg.ClientID,
-					CleanStart: true, // while persistence is not supported we should probably start clean...
-				}
+				cp := cfg.buildConnectPacket()
 				var ca *paho.Connack
 				ca, err = cli.Connect(connectionCtx, cp) // will return an error if the connection is unsuccessful (checks the reason code)
 				if err == nil {                          // Successfully connected


### PR DESCRIPTION
Closes #68 allowing configuration of Connect packet parameters in autopaho.

Slight variations on the proposed interface, but should be essentially the same. 
As this is my first PR on Paho repos, I'm happy to iterate with any feedback provided.


**Testing**

As the autopaho module did not previously have dedicated tests, I have implemented a unittest only for the ClientConfig construction, and related validation of the Connect packet my changes introduced.

I'm also using my fork in an implementation, and it's demonstrably working, correctly authenticating with a broker, etc. 🙂  
