### PR TITLE
Introduce AtomicWriteTo(*sync.Mutex, io.Writer) for thead-safe writing to net.Conn

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -33,7 +33,11 @@ type (
 	// are required to be set, defaults are provided for Persistence, MIDs,
 	// PingHandler, PacketTimeout and Router.
 	ClientConfig struct {
-		ClientID      string
+		ClientID string
+		// Conn is the connection to broker.
+		// BEWARE that most wrapped net.Conn implementations like tls.Conn are
+		// not thread safe for writing. To fix, use packets.NewThreadSafeConn
+		// wrapper or extend the custom net.Conn struct with sync.Locker.
 		Conn          net.Conn
 		MIDs          MIDService
 		AuthHandler   Auther


### PR DESCRIPTION
This PR fixes race conditions when writing to net.Conn that doesn't implement
net.writeBuffers, such as tls.Conn.

There is an example reproduction of the race condition (and the fix) in `authopaho/examples/docker` at https://github.com/thejan2009/paho.golang/commits/packets-writeto

Closes #81 