### PR TITLE
Fix StandardRouter topic matching for shared subscriptions

### DIFF
--- a/paho/router.go
+++ b/paho/router.go
@@ -139,7 +139,7 @@ func routeSplit(route string) []string {
 	}
 	var result []string
 	if strings.HasPrefix(route, "$share") {
-		result = strings.Split(route, "/")[1:]
+		result = strings.Split(route, "/")[2:]
 	} else {
 		result = strings.Split(route, "/")
 	}


### PR DESCRIPTION
**ECA - Eclipse Contributer Agreement**

Ensure you have a valid, signed [ECA](https://www.eclipse.org/legal/ECA.php) for the email address associated with your Github account (or you sign off your PR with an ECA'd address)

Please provide enough information so that others can review your pull request: See issue #93 


**Closing issues**
Put `closes #93` in your comment to auto-close the issue that your PR fixes.
