### PR TITLE
Fix router_test.go

### DIFF
--- a/paho/router_test.go
+++ b/paho/router_test.go
@@ -22,7 +22,7 @@ func Test_match(t *testing.T) {
 		{"hash2", "a/#", "a/b", true},
 		{"hash3", "b/#", "a/b", false},
 		{"hash4", "#", "", true},
-		{"share1", "$share/a/b", "a/b", true},
+		{"share1", "$share/group1/a/b", "a/b", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
closes #96 

Successful logs of make test below.

Is there any scope for this project to use a free CI tool? I think github has one for open source projects. I think the project should be performing a make test and make build as a pre PR check.

=== RUN   Test_match
=== RUN   Test_match/basic1
=== RUN   Test_match/basic2
=== RUN   Test_match/plus1
=== RUN   Test_match/plus2
=== RUN   Test_match/plus3
=== RUN   Test_match/plus4
=== RUN   Test_match/hash1
=== RUN   Test_match/hash2
=== RUN   Test_match/hash3
=== RUN   Test_match/hash4
=== RUN   Test_match/share1
--- PASS: Test_match (0.00s)
    --- PASS: Test_match/basic1 (0.00s)
    --- PASS: Test_match/basic2 (0.00s)
    --- PASS: Test_match/plus1 (0.00s)
    --- PASS: Test_match/plus2 (0.00s)
    --- PASS: Test_match/plus3 (0.00s)
    --- PASS: Test_match/plus4 (0.00s)
    --- PASS: Test_match/hash1 (0.00s)
    --- PASS: Test_match/hash2 (0.00s)
    --- PASS: Test_match/hash3 (0.00s)
    --- PASS: Test_match/hash4 (0.00s)
    --- PASS: Test_match/share1 (0.00s)
=== RUN   Test_routeIncludesTopic
--- PASS: Test_routeIncludesTopic (0.00s)
=== RUN   Test_routeSplit
--- PASS: Test_routeSplit (0.00s)
PASS
ok  	github.com/eclipse/paho.golang/paho	29.493s
