### PR TITLE
Add RPC Timout request and prevent blocking while waiting response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 autopaho/cmd/rpc/.env
+.idea

--- a/paho/cmd/rpc/main.go
+++ b/paho/cmd/rpc/main.go
@@ -179,7 +179,10 @@ func main() {
 
 	fmt.Printf("Connected to %s\n", *server)
 
-	h, err := rpc.NewHandler(ctx, c)
+	h, err := rpc.NewHandler(ctx, rpc.HandlerInput{
+		Client:         c,
+		RequestTimeout: nil, // no timeouts
+	})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
closes #108

--

this PR is related to this request https://github.com/eclipse/paho.golang/pull/98

> The most significant issue was the rpc.Handler.Request function, in which the go routine could block indefinitely waiting for a response from the server.

I found that there are missed fixes from the last PR on the following line
https://github.com/eclipse/paho.golang/blob/e818d6af9263c1ff1c68749d9e87defb8f51690f/paho/extensions/rpc/rpc.go#L76

also, I proposed request timeout on RPC Request