### PR TITLE
Fix typo of protocol error code of CONNACK

### DIFF
--- a/packets/connack.go
+++ b/packets/connack.go
@@ -18,7 +18,7 @@ const (
 	ConnackSuccess                     = 0x00
 	ConnackUnspecifiedError            = 0x80
 	ConnackMalformedPacket             = 0x81
-	ConnackProtocolError               = 0x81
+	ConnackProtocolError               = 0x82
 	ConnackImplementationSpecificError = 0x83
 	ConnackUnsupportedProtocolVersion  = 0x84
 	ConnackInvalidClientID             = 0x85


### PR DESCRIPTION
**Changing**
As mentioned in #120, fix protocol error code of CONNACK according to the spec. 

As bellow, protocol error code of DISCONNECT is 0x82,  CONNACK = 0x81 seems to be just typo.
https://github.com/eclipse/paho.golang/blob/d63b3b28d25ff73076c8846c92c4d062503e646e/packets/disconnect.go#L26

**Testing**
Test was passed by ```make test```

**Closing issues**
closes #120
