### PR TITLE
implement simplified pinger and add pinger tests

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -219,7 +219,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 
 	c.debug.Println("waiting for CONNACK/AUTH")
 	var (
-		caPacket    *packets.Connack
+		caPacket *packets.Connack
 		// We use buffered channels to prevent goroutine leak. The Details are below.
 		// - c.expectConnack waits to send data to caPacketCh or caPacketErr.
 		// - If connCtx is cancelled (done) before c.expectConnack finishes to send data to either "unbuffered" channel,

--- a/paho/pinger_test.go
+++ b/paho/pinger_test.go
@@ -1,0 +1,85 @@
+package paho
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.golang/packets"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPingerPingHandlerTimeout(t *testing.T) {
+	fakeServerConn, fakeClientConn := net.Pipe()
+	defer fakeServerConn.Close()
+	defer fakeClientConn.Close()
+
+	serverConnBuffer := make([]byte, 1024)
+
+	go func() {
+		// keep reading from fakeServerConn and discard the values. exit when fakeServerConn is closed.
+		for {
+			_, err := fakeServerConn.Read(serverConnBuffer)
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	pfhValues := make(chan error)
+	pfh := func(e error) {
+		pfhValues <- e
+	}
+
+	pingHandler := DefaultPingerWithCustomFailHandler(pfh)
+
+	go func() {
+		pingHandler.Start(fakeClientConn, time.Second)
+	}()
+	defer pingHandler.Stop()
+
+	select {
+	case <-time.After(time.Second * 3):
+		t.Error("pingHandler did not timeout in time")
+	case err := <-pfhValues:
+		assert.EqualError(t, err, "ping resp timed out")
+	}
+}
+
+func TestPingerPingHandlerSuccess(t *testing.T) {
+	ts := newTestServer()
+	clientConn := ts.ClientConn()
+	go ts.Run()
+	defer ts.Stop()
+
+	pfhValues := make(chan error)
+	pfh := func(e error) {
+		pfhValues <- e
+	}
+
+	pingHandler := DefaultPingerWithCustomFailHandler(pfh)
+
+	go func() {
+		for {
+			recv, err := packets.ReadPacket(clientConn)
+			if err != nil {
+				return
+			}
+			if recv.Type == packets.PINGRESP {
+				pingHandler.PingResp()
+			}
+		}
+	}()
+
+	go func() {
+		pingHandler.Start(ts.ClientConn(), time.Second*5)
+	}()
+	defer pingHandler.Stop()
+
+	select {
+	case <-time.After(time.Second * 30):
+		// Pass
+	case <-pfhValues:
+		t.Error("pingFailHandler was called when it should not have been")
+	}
+}


### PR DESCRIPTION
close #137 

Here's a proposal for a pinger design. Essentially, it sends a PINGREQ and checks for a PINGRESP in lockstep on a keepalive time interval. It is simpler than the currently existing one, but still meets the requirements for the MQTT spec. IMO, keeping it simple is better, especially since advanced users can provide their own implementation if they want to. 

I also added some tests, though the tests do add a non-trivial amount of runtime to the test suite.