### PR TITLE
Allow initializing MIDs with in-use IDs, remove Clear(), use RWMutex for Get()

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -138,7 +138,7 @@ func NewClient(conf ClientConfig) *Client {
 		c.Persistence = &noopPersistence{}
 	}
 	if c.MIDs == nil {
-		c.MIDs = &MIDs{index: make([]*CPContext, int(midMax))}
+		c.MIDs = NewMIDs(nil)
 	}
 	if c.PacketTimeout == 0 {
 		c.PacketTimeout = 10 * time.Second
@@ -219,7 +219,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 
 	c.debug.Println("waiting for CONNACK/AUTH")
 	var (
-		caPacket    *packets.Connack
+		caPacket *packets.Connack
 		// We use buffered channels to prevent goroutine leak. The Details are below.
 		// - c.expectConnack waits to send data to caPacketCh or caPacketErr.
 		// - If connCtx is cancelled (done) before c.expectConnack finishes to send data to either "unbuffered" channel,

--- a/paho/message_ids.go
+++ b/paho/message_ids.go
@@ -17,22 +17,14 @@ const (
 // free message ids to be used.
 var ErrorMidsExhausted = errors.New("all message ids in use")
 
-// ErrorMidInUse is returned from ClaimID() when the requested
-// message id is already in use.
-var ErrorMidInUse = errors.New("message id already in use")
-
 // MIDService defines the interface for a struct that handles the
 // relationship between message ids and CPContexts
 // Request() takes a *CPContext and returns a uint16 that is the
 // messageid that should be used by the code that called Request()
-// ClaimID() takes a unit16 that is a messageid and its corresponding
-// *CPContext to mark that messageid as in use. This is used when
-// reconnecting with an existing session that has outstanding messages
 // Get() takes a uint16 that is a messageid and returns the matching
 // *CPContext that the MIDService has associated with that messageid
 // Free() takes a uint16 that is a messageid and instructs the MIDService
 // to mark that messageid as available for reuse
-// Clear() resets the internal state of the MIDService
 type MIDService interface {
 	Request(*CPContext) (uint16, error)
 	Get(uint16) *CPContext
@@ -57,6 +49,9 @@ type MIDs struct {
 	index   []*CPContext // index of slice is (messageid - 1)
 }
 
+// NewMIDs returns a new MIDs instance with message IDs claimed using
+// the information in the supplied map. nil may be passed if no message IDs
+// need to be claimed.
 func NewMIDs(inUse map[uint16]*CPContext) *MIDs {
 	m := &MIDs{index: make([]*CPContext, midMax)}
 	for mid, c := range inUse {

--- a/paho/message_ids_test.go
+++ b/paho/message_ids_test.go
@@ -121,27 +121,27 @@ func TestUsingFullBandOfMID(t *testing.T) {
 	}
 }
 
-func TestMidClaimID(t *testing.T) {
-	m := &MIDs{index: make([]*CPContext, midMax)}
+func TestMidNewMIDs(t *testing.T) {
+	// Create a new MIDs with a map that has an entry
+	inUse := make(map[uint16]*CPContext)
 	cp := &CPContext{}
+	inUse[5] = cp
+	m := NewMIDs(inUse)
+	assert.Equal(t, cp, m.Get(5))
+	for i := uint16(1); i < 5; i++ {
+		assert.Nil(t, m.Get(i))
+	}
+	for i := uint16(6); i < midMax; i++ {
+		assert.Nil(t, m.Get(i))
+	}
+	assert.Nil(t, m.Get(midMax))
 
-	// Claim ID and then get the CPContext value back
-	err := m.ClaimID(42, cp)
-	assert.Nil(t, err)
-	assert.Equal(t, cp, m.Get(42))
-
-	// Free the ID, then claim it again
-	m.Free(42)
-	assert.Nil(t, m.Get(42))
-	err = m.ClaimID(42, cp)
-	assert.Nil(t, err)
-	assert.Equal(t, cp, m.Get(42))
-
-	// Claim an ID that is already in use
-	id, err := m.Request(cp)
-	assert.Nil(t, err)
-	err = m.ClaimID(id, cp)
-	assert.ErrorIs(t, err, ErrorMidInUse)
+	// Create a new MIDs that is empty
+	m = NewMIDs(nil)
+	for i := uint16(1); i < midMax; i++ {
+		assert.Nil(t, m.Get(i))
+	}
+	assert.Nil(t, m.Get(midMax))
 }
 
 func BenchmarkRequestMID(b *testing.B) {


### PR DESCRIPTION
As discussed in #134, we need a way to claim packet IDs as a prerequisite for connecting with existing sessions. This implements that. In addition, I put an RWMutex in since calls to Get() can safely happen in parallel.