### PR TITLE
Handle Orphaned Operations

### DIFF
--- a/paho/cp_pubresp.go
+++ b/paho/cp_pubresp.go
@@ -8,6 +8,7 @@ type (
 	PublishResponse struct {
 		Properties *PublishResponseProperties
 		ReasonCode byte
+		PacketID   uint16
 	}
 
 	// PublishResponseProperties is the properties associated with
@@ -23,6 +24,7 @@ type (
 func PublishResponseFromPuback(pa *packets.Puback) *PublishResponse {
 	return &PublishResponse{
 		ReasonCode: pa.ReasonCode,
+		PacketID:   pa.PacketID,
 		Properties: &PublishResponseProperties{
 			ReasonString: pa.Properties.ReasonString,
 			User:         UserPropertiesFromPacketUser(pa.Properties.User),
@@ -35,6 +37,7 @@ func PublishResponseFromPuback(pa *packets.Puback) *PublishResponse {
 func PublishResponseFromPubcomp(pc *packets.Pubcomp) *PublishResponse {
 	return &PublishResponse{
 		ReasonCode: pc.ReasonCode,
+		PacketID:   pc.PacketID,
 		Properties: &PublishResponseProperties{
 			ReasonString: pc.Properties.ReasonString,
 			User:         UserPropertiesFromPacketUser(pc.Properties.User),
@@ -47,6 +50,7 @@ func PublishResponseFromPubcomp(pc *packets.Pubcomp) *PublishResponse {
 func PublishResponseFromPubrec(pr *packets.Pubrec) *PublishResponse {
 	return &PublishResponse{
 		ReasonCode: pr.ReasonCode,
+		PacketID:   pr.PacketID,
 		Properties: &PublishResponseProperties{
 			ReasonString: pr.Properties.ReasonString,
 			User:         UserPropertiesFromPacketUser(pr.Properties.User),

--- a/paho/orphaned_ops.go
+++ b/paho/orphaned_ops.go
@@ -1,0 +1,85 @@
+package paho
+
+import (
+	"github.com/eclipse/paho.golang/packets"
+)
+
+type OrphanedOps interface {
+	AddOp(<-chan packets.ControlPacket)
+	Stop()
+}
+
+type StandardOrphanedOps struct {
+	stop                chan struct{}
+	publishCallback     func(*PublishResponse)
+	subscribeCallback   func(*Suback)
+	unsubscribeCallback func(*Unsuback)
+}
+
+type OrphanedOperationPoolCallbacks struct {
+	PublishCallback     func(*PublishResponse)
+	SubscribeCallback   func(*Suback)
+	UnsubscribeCallback func(*Unsuback)
+}
+
+func NewStandardOrphanedOps(callbacks OrphanedOperationPoolCallbacks) *StandardOrphanedOps {
+	var (
+		publishCallback     func(*PublishResponse)
+		subscribeCallback   func(*Suback)
+		unsubscribeCallback func(*Unsuback)
+	)
+	if callbacks.PublishCallback == nil {
+		publishCallback = func(*PublishResponse) {}
+	} else {
+		publishCallback = callbacks.PublishCallback
+	}
+	if callbacks.SubscribeCallback == nil {
+		subscribeCallback = func(*Suback) {}
+	} else {
+		subscribeCallback = callbacks.SubscribeCallback
+	}
+	if callbacks.UnsubscribeCallback == nil {
+		unsubscribeCallback = func(*Unsuback) {}
+	} else {
+		unsubscribeCallback = callbacks.UnsubscribeCallback
+	}
+
+	return &StandardOrphanedOps{
+		stop:                make(chan struct{}),
+		publishCallback:     publishCallback,
+		subscribeCallback:   subscribeCallback,
+		unsubscribeCallback: unsubscribeCallback,
+	}
+}
+
+func (p *StandardOrphanedOps) AddOp(opResp <-chan packets.ControlPacket) {
+	go func() {
+		var ok bool
+		var opResult packets.ControlPacket
+		select {
+		case <-p.stop:
+			return
+		case opResult, ok = <-opResp:
+			if !ok {
+				return
+			}
+		}
+		switch opResult.Type {
+
+		case packets.PUBACK:
+			p.publishCallback(PublishResponseFromPuback(opResult.Content.(*packets.Puback)))
+		case packets.PUBREC:
+			p.publishCallback(PublishResponseFromPubrec(opResult.Content.(*packets.Pubrec)))
+		case packets.PUBCOMP:
+			p.publishCallback(PublishResponseFromPubcomp(opResult.Content.(*packets.Pubcomp)))
+		case packets.SUBACK:
+			p.subscribeCallback(SubackFromPacketSuback(opResult.Content.(*packets.Suback)))
+		case packets.UNSUBACK:
+			p.unsubscribeCallback(UnsubackFromPacketUnsuback(opResult.Content.(*packets.Unsuback)))
+		}
+	}()
+}
+
+func (p *StandardOrphanedOps) Stop() {
+	close(p.stop)
+}


### PR DESCRIPTION
related issue: #134

Here's a proposal for a design to handle orphaned operations (PUBLISH w/ QoS >0, SUBSCRIBE, and UNSUBSCRIBE). 

This would allow the user to get back the result of an operation after a timeout. More importantly, this allows us to kick off a PUBLISH operation in the background when connecting with an existing session comes into the picture.

It seems to work as intended, and I'm happy to write some tests for it. However, I wanted to get feedback on this before I go through the effort since this is a substantial change and I'm not sure if this is the direction the project would be willing to take.

The basic idea is that PUBLISH w/ QoS >0, SUBSCRIBE, and UNSUBSCRIBE are handled inside an internal goroutine that puts the result in a channel when it is received from the server. The user-facing Publish(), Subscribe(), and Unsubscribe() functions call the internal functions. If the context is cancelled before the internal goroutines return a result on the channel, the user-facing function returns with an error and the operation is still tracked in the background. There are user-configurable callbacks to get the results for orphaned operations. 