### PR TITLE
Print control packet type string instead of number

### DIFF
--- a/paho/server_test.go
+++ b/paho/server_test.go
@@ -72,7 +72,7 @@ func (t *testServer) Run() {
 				log.Println("error in test server reading packet", err)
 				return
 			}
-			log.Println("test server received a control packet:", recv.Type)
+			log.Println("test server received a control packet:", recv.PacketType())
 			switch recv.Type {
 			case packets.CONNECT:
 				log.Println("received", recv.Content.(*packets.Connect))


### PR DESCRIPTION
Very small change, this makes the test logs easier to interpret. 