### PR TITLE
Use network loops to read/write packets in isolated goroutines

### DIFF
--- a/packets/auth.go
+++ b/packets/auth.go
@@ -70,8 +70,10 @@ func (a *Auth) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (a *Auth) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: AUTH}}
-	cp.Content = a
+	return a.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (a *Auth) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: AUTH}, Content: a}
 }

--- a/packets/connack.go
+++ b/packets/connack.go
@@ -43,7 +43,7 @@ func (c *Connack) String() string {
 	return fmt.Sprintf("CONNACK: ReasonCode:%d SessionPresent:%t\nProperties:\n%s", c.ReasonCode, c.SessionPresent, c.Properties)
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (c *Connack) Unpack(r *bytes.Buffer) error {
 	connackFlags, err := r.ReadByte()
 	if err != nil {
@@ -88,10 +88,12 @@ func (c *Connack) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (c *Connack) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: CONNACK}}
-	cp.Content = c
+	return c.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (c *Connack) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: CONNACK}, Content: c}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/connect.go
+++ b/packets/connect.go
@@ -85,7 +85,7 @@ func (c *Connect) UnpackFlags(b byte) {
 	c.UsernameFlag = 1&(b>>7) > 0
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (c *Connect) Unpack(r *bytes.Buffer) error {
 	var err error
 
@@ -182,8 +182,10 @@ func (c *Connect) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (c *Connect) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: CONNECT}}
-	cp.Content = c
+	return c.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (c *Connect) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: CONNECT}, Content: c}
 }

--- a/packets/disconnect.go
+++ b/packets/disconnect.go
@@ -79,10 +79,12 @@ func (d *Disconnect) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (d *Disconnect) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: DISCONNECT}}
-	cp.Content = d
+	return d.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (d *Disconnect) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: DISCONNECT}, Content: d}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -39,6 +39,7 @@ type (
 		Unpack(*bytes.Buffer) error
 		Buffers() net.Buffers
 		WriteTo(io.Writer) (int64, error)
+		ToControlPacket() *ControlPacket
 	}
 
 	// FixedHeader is the definition of a control packet fixed header

--- a/packets/pingreq.go
+++ b/packets/pingreq.go
@@ -26,8 +26,10 @@ func (p *Pingreq) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Pingreq) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PINGREQ}}
-	cp.Content = p
+	return p.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Pingreq) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PINGREQ}, Content: p}
 }

--- a/packets/pingresp.go
+++ b/packets/pingresp.go
@@ -26,8 +26,10 @@ func (p *Pingresp) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Pingresp) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PINGRESP}}
-	cp.Content = p
+	return p.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Pingresp) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PINGRESP}, Content: p}
 }

--- a/packets/puback.go
+++ b/packets/puback.go
@@ -41,7 +41,7 @@ func (p *Puback) String() string {
 	return b.String()
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (p *Puback) Unpack(r *bytes.Buffer) error {
 	var err error
 	success := r.Len() == 2
@@ -82,10 +82,12 @@ func (p *Puback) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Puback) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PUBACK}}
-	cp.Content = p
+	return p.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Puback) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PUBACK}, Content: p}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/pubcomp.go
+++ b/packets/pubcomp.go
@@ -34,7 +34,7 @@ func (p *Pubcomp) String() string {
 	return b.String()
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (p *Pubcomp) Unpack(r *bytes.Buffer) error {
 	var err error
 	success := r.Len() == 2
@@ -76,10 +76,12 @@ func (p *Pubcomp) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Pubcomp) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PUBCOMP}}
-	cp.Content = p
+	return p.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Pubcomp) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PUBCOMP}, Content: p}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/publish.go
+++ b/packets/publish.go
@@ -23,7 +23,7 @@ func (p *Publish) String() string {
 	return fmt.Sprintf("PUBLISH: PacketID:%d QOS:%d Topic:%s Duplicate:%t Retain:%t Payload:\n%s\nProperties\n%s", p.PacketID, p.QoS, p.Topic, p.Duplicate, p.Retain, string(p.Payload), p.Properties)
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (p *Publish) Unpack(r *bytes.Buffer) error {
 	var err error
 	p.Topic, err = readString(r)
@@ -65,6 +65,11 @@ func (p *Publish) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Publish) WriteTo(w io.Writer) (int64, error) {
+	return p.ToControlPacket().WriteTo(w)
+}
+
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Publish) ToControlPacket() *ControlPacket {
 	f := p.QoS << 1
 	if p.Duplicate {
 		f |= 1 << 3
@@ -73,8 +78,5 @@ func (p *Publish) WriteTo(w io.Writer) (int64, error) {
 		f |= 1
 	}
 
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PUBLISH, Flags: f}}
-	cp.Content = p
-
-	return cp.WriteTo(w)
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PUBLISH, Flags: f}, Content: p}
 }

--- a/packets/pubrec.go
+++ b/packets/pubrec.go
@@ -41,7 +41,7 @@ func (p *Pubrec) String() string {
 	return b.String()
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (p *Pubrec) Unpack(r *bytes.Buffer) error {
 	var err error
 	success := r.Len() == 2
@@ -84,10 +84,12 @@ func (p *Pubrec) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Pubrec) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PUBREC}}
-	cp.Content = p
+	return p.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Pubrec) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PUBREC}, Content: p}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/pubrel.go
+++ b/packets/pubrel.go
@@ -28,7 +28,7 @@ func (p *Pubrel) String() string {
 	return b.String()
 }
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (p *Pubrel) Unpack(r *bytes.Buffer) error {
 	var err error
 	success := r.Len() == 2
@@ -70,8 +70,10 @@ func (p *Pubrel) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (p *Pubrel) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: PUBREL, Flags: 2}}
-	cp.Content = p
+	return p.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (p *Pubrel) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: PUBREL, Flags: 2}, Content: p}
 }

--- a/packets/suback.go
+++ b/packets/suback.go
@@ -34,7 +34,7 @@ const (
 	SubackWildcardsubscriptionsnotsupported   = 0xA2
 )
 
-//Unpack is the implementation of the interface required function for a packet
+// Unpack is the implementation of the interface required function for a packet
 func (s *Suback) Unpack(r *bytes.Buffer) error {
 	var err error
 	s.PacketID, err = readUint16(r)
@@ -63,10 +63,12 @@ func (s *Suback) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (s *Suback) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: SUBACK}}
-	cp.Content = s
+	return s.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (s *Suback) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: SUBACK}, Content: s}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/subscribe.go
+++ b/packets/subscribe.go
@@ -111,8 +111,10 @@ func (s *Subscribe) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (s *Subscribe) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: SUBSCRIBE, Flags: 2}}
-	cp.Content = s
+	return s.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (s *Subscribe) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: SUBSCRIBE, Flags: 2}, Content: s}
 }

--- a/packets/unsuback.go
+++ b/packets/unsuback.go
@@ -58,10 +58,12 @@ func (u *Unsuback) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (u *Unsuback) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: UNSUBACK}}
-	cp.Content = u
+	return u.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (u *Unsuback) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: UNSUBACK}, Content: u}
 }
 
 // Reason returns a string representation of the meaning of the ReasonCode

--- a/packets/unsubscribe.go
+++ b/packets/unsubscribe.go
@@ -60,8 +60,10 @@ func (u *Unsubscribe) Buffers() net.Buffers {
 
 // WriteTo is the implementation of the interface required function for a packet
 func (u *Unsubscribe) WriteTo(w io.Writer) (int64, error) {
-	cp := &ControlPacket{FixedHeader: FixedHeader{Type: UNSUBSCRIBE, Flags: 2}}
-	cp.Content = u
+	return u.ToControlPacket().WriteTo(w)
+}
 
-	return cp.WriteTo(w)
+// ToControlPacket is the implementation of the interface required function for a packet
+func (u *Unsubscribe) ToControlPacket() *ControlPacket {
+	return &ControlPacket{FixedHeader: FixedHeader{Type: UNSUBSCRIBE, Flags: 2}, Content: u}
 }


### PR DESCRIPTION
Here's a proposal to make the `client.go` read and write packets in isolated goroutines. 

I think this makes things easier to work with and makes errors on the connection easier to deal with.

Thanks @BertKleewein for the inspiration!