### PR TITLE
Add CONNACK packet to autopaho OnConnectError func

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -52,7 +52,7 @@ type ClientConfig struct {
 	AttemptConnection func(context.Context, ClientConfig, *url.URL) (net.Conn, error)
 
 	OnConnectionUp func(*ConnectionManager, *paho.Connack) // Called (within a goroutine) when a connection is made (including reconnection). Connection Manager passed to simplify subscriptions.
-	OnConnectError func(error)                             // Called (within a goroutine) whenever a connection attempt fails
+	OnConnectError func(error)                             // Called (within a goroutine) whenever a connection attempt fails. Will wrap autopaho.ConnackError on server deny.
 
 	Debug      paho.Logger // By default set to NOOPLogger{},set to a logger for debugging info
 	PahoDebug  paho.Logger // debugger passed to the paho package (will default to NOOPLogger{})

--- a/autopaho/error.go
+++ b/autopaho/error.go
@@ -57,3 +57,31 @@ type DisconnectError struct{ err string }
 func (d *DisconnectError) Error() string {
 	return d.err
 }
+
+// ConnackError will be passed when the server denies connection in CONNACK packet
+type ConnackError struct {
+	ReasonCode byte   // CONNACK reason code
+	Reason     string // CONNACK Reason string from properties
+	Err        error  // underlying error
+}
+
+// NewConnackError returns a new ConnackError
+func NewConnackError(err error, connack *paho.Connack) *ConnackError {
+	reason := ""
+	if connack.Properties != nil {
+		reason = connack.Properties.ReasonString
+	}
+	return &ConnackError{
+		ReasonCode: connack.ReasonCode,
+		Reason:     reason,
+		Err:        err,
+	}
+}
+
+func (c *ConnackError) Error() string {
+	return fmt.Sprintf("server denied connect (reason: %d): %s", c.ReasonCode, c.Err)
+}
+
+func (c *ConnackError) Unwrap() error {
+	return c.Err
+}


### PR DESCRIPTION
This enables handling connection errors based on response code received by the server.

Fixes #152 
