### PR TITLE
Autopaho: Call error call back a maximum of once per connection

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -226,8 +226,9 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 
 			var err error
 			select {
-			case err = <-errChan: // Message on error channel indicates connection has (or will) drop.
+			case err = <-errChan: // Message on the error channel indicates connection has (or will) drop.
 			case <-innerCtx.Done():
+				eh.shutdown() // Prevent any errors triggered by closure of context from reaching user
 				// As the connection is up, we call disconnect to shut things down cleanly
 				if err = c.cli.Disconnect(&paho.Disconnect{ReasonCode: 0}); err != nil {
 					cfg.Debug.Printf("disconnect returned error: %s\n", err)

--- a/autopaho/error.go
+++ b/autopaho/error.go
@@ -58,10 +58,9 @@ func (e *errorHandler) handleError(err error) bool {
 		e.debug.Printf("received error: %s", err)
 		errChan <- err
 		return true
-	} else {
-		e.debug.Printf("received extra error: %s", err)
-		return false
 	}
+	e.debug.Printf("received extra error: %s", err)
+	return false
 }
 
 // DisconnectError will be passed when the server requests disconnection (allows this error type to be detected)

--- a/autopaho/internal/testserver/testserver.go
+++ b/autopaho/internal/testserver/testserver.go
@@ -127,6 +127,11 @@ func New(logger Logger) *Instance {
 	}
 }
 
+// Connected returns true if the test server has an active connection with the client
+func (i *Instance) Connected() bool {
+	return i.connected.Load()
+}
+
 // Connect establishes a connection to the test broker
 // Note that this can fail!
 // Returns a net.Conn (to pass to paho), a channel that will be closed when connection has shutdown and


### PR DESCRIPTION
autoPaho had the potential to call the error call beck multiple times in relation to one event.
This mirrored the `paho` functionality but does not make much sense from an end user perspective,
so this change prevents multiple calls to `OnClientError` in relation to a single connection.
We also prevent errors from being logger when the user has called `Disconnect` (it's not an error
if it's the result of a request) and add a test.

closes #157