### PR TITLE
update required go to 1.21 for context.AfterFunc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eclipse/paho.golang
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.5.9


### PR DESCRIPTION
context.AfterFunc wasn't introduced until 1.21

closes #177 