### PR TITLE
Reimplement receive-maximum quota handling

### DIFF
--- a/paho/session/state/ids_test.go
+++ b/paho/session/state/ids_test.go
@@ -16,6 +16,7 @@ import (
 func TestPacketIdAllocateAndFreeAll(t *testing.T) {
 	ss := NewInMemory()
 	ss.clientPackets = make(map[uint16]clientGenerated)
+	ss.inflight = newSendQuota(200) // not testing this but its needed for endClientGenerated to work
 
 	// Use full band
 	cpChan := make(chan packets.ControlPacket)
@@ -89,6 +90,7 @@ func TestPacketIdAllocateAndFreeAll(t *testing.T) {
 func TestPacketIdHoles(t *testing.T) {
 	ss := NewInMemory()
 	ss.clientPackets = make(map[uint16]clientGenerated)
+	ss.inflight = newSendQuota(200) // not testing this but its needed for endClientGenerated to work
 
 	// For this test we ignore responses
 	cpChan := make(chan packets.ControlPacket)

--- a/paho/session/state/sendquota.go
+++ b/paho/session/state/sendquota.go
@@ -1,0 +1,106 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// Implements send quota as described in section 4.9 of the spec. This is used to honour the receive-maximum
+// received from the broker; each time a qos1/2 PUBLISH is to be sent `Acquire` must be called, and this will
+// block until a slot is available (`Release` is called when the message is fully acknowledged).
+
+// This function was previously performed by `golang.org/x/sync/semaphore` but, as per the MQTT spec:
+//
+// > The send quota is not incremented if it is already equal to the initial send quota. The attempt to increment above
+// > the initial send quota might be caused by the re-transmission of a PUBREL packet after a new Network Connection is
+// > established.
+//
+// The result of this happening with `semaphore` is a `panic` which is not ideal.
+// It is also possible (as per issue #179) that bugs, or unexpected circumstances, may result in the same situation. For
+// example: if the local session state is lost but there is a session state on the server (meaning it sends an unexpected
+// PUBACK).
+//
+// Note: If the broker does not correctly acknowledge messages, then the quota will be consumed over time. There
+// should probably be a process to drop the connection if there are no slots available and no acknowledgements have been
+// received recently.
+
+// ErrUnexpectedRelease is for logging only (to help identify if there are issues with state management)
+var ErrUnexpectedRelease = errors.New("release called when quota at initial value")
+
+// newSendQuota creates a new tracker limited to quota concurrent messages
+func newSendQuota(quota uint16) *sendQuota {
+	w := &sendQuota{initialQuota: quota, quota: quota}
+	return w
+}
+
+// sendQuota provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type sendQuota struct {
+	mu           sync.Mutex
+	initialQuota uint16
+	quota        uint16
+	waiters      []chan<- struct{} // using a slice because would generally expect this to be small
+}
+
+// Retransmit takes a slot for a message that is being redelivered and will never block.
+// This is not in compliance with the MQTT v5 spec and should be removed in the future.
+func (s *sendQuota) Retransmit() error {
+	return s.acquire(context.Background(), true)
+}
+
+// Acquire waits for a slot to become available so a message can be published
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *sendQuota) Acquire(ctx context.Context) error {
+	return s.acquire(ctx, false)
+}
+
+// acquire attempts to allocate a slot for a message to be published
+// If noWait is true quota will be ignored and the call will return immediately, otherwise acquire will block
+// until a slot is available.
+func (s *sendQuota) acquire(ctx context.Context, noWait bool) error {
+	s.mu.Lock()
+	if noWait || (s.quota > 0 && len(s.waiters) == 0) {
+		s.quota-- // Note: can go < 0 if noWait used
+		s.mu.Unlock()
+		return nil
+	}
+
+	// We need to join the queue
+	ready := make(chan struct{})
+	s.waiters = append(s.waiters, ready)
+	s.mu.Unlock()
+
+	var err error
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancellation.
+			err = nil
+		default:
+		}
+		s.mu.Unlock()
+	case <-ready: // Note that quota already accounts for this item
+	}
+	return err
+}
+
+// Release releases slot for the specified message ID
+// error is for logging only (ref issue #179)
+func (s *sendQuota) Release() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.quota >= 0 && len(s.waiters) > 0 { // Possible quota could go negative when using noWait
+		close(s.waiters[0])
+		s.waiters = append(s.waiters[:0], s.waiters[1:]...)
+	} else if s.quota < s.initialQuota {
+		s.quota++
+		return nil
+	}
+	return ErrUnexpectedRelease
+}

--- a/paho/session/state/sendquota_test.go
+++ b/paho/session/state/sendquota_test.go
@@ -1,0 +1,201 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestQuotaBasics performs basic testing of allocating/releasing message ids in inflight
+func TestQuotaBasics(t *testing.T) {
+	t.Parallel()
+
+	it := newSendQuota(5)
+
+	// We should be able to acquire until the quota is hit
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	for i := uint32(0); i < 5; i++ {
+		if err := it.Acquire(ctx); err != nil {
+			t.Fatalf("failed to get slot: %v", err)
+		}
+	}
+	cancel()
+
+	// subsequent waiters should block until Release is called
+	for i := uint32(1); i < 5; i++ {
+		release := make(chan struct{})
+		released := make(chan error, 1)
+		ctx, cancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
+		go func() {
+			<-release
+			it.Release()
+			close(released)
+		}()
+
+		aResult := make(chan error, 1)
+		go func() {
+			aResult <- it.Acquire(ctx)
+		}()
+		select {
+		case err := <-aResult:
+			t.Fatalf("slot should not be gained before previous one released: %d, %v", i, err)
+		case <-time.After(10 * time.Millisecond):
+		}
+
+		close(release)
+		select {
+		case <-released:
+		case <-time.After(10 * time.Millisecond):
+			t.Fatalf("slot should have been released")
+		}
+		cancel()
+	}
+
+	// Waiters should be released in order
+	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
+	aResult := make(chan struct {
+		uint32
+		error
+	})
+	for i := uint32(0); i < 5; i++ {
+		go func(i uint32) {
+			aResult <- struct {
+				uint32
+				error
+			}{i, it.Acquire(ctx)}
+		}(i)
+		time.Sleep(time.Millisecond) // we want slots to be requested in known order
+	}
+	select {
+	case result := <-aResult:
+		t.Fatalf("await should not complete before slot is available: %v", result.error)
+	default:
+	}
+	for i := uint32(0); i < 5; i++ {
+		it.Release()
+		time.Sleep(time.Millisecond) // provide time for release to be processed
+	}
+	time.Sleep(time.Millisecond) // allow time for slots to be allocated
+	for i := uint32(0); i < 5; i++ {
+		select {
+		case result := <-aResult:
+			if result.error != nil {
+				t.Fatalf("unexpected error: %v", result.error)
+			}
+			if result.uint32 != i {
+				t.Fatalf("release out of order; expected %d, got %d", i, result.uint32)
+			}
+		default:
+			t.Fatalf("await should have compelted")
+		}
+	}
+
+	// Check internal state
+	if it.quota != 0 {
+		t.Fatalf("expected 0 quota: %v", it.quota)
+	}
+	if len(it.waiters) != 0 {
+		t.Fatalf("expected waiters to be empty: %v", it.waiters)
+	}
+
+	// Empty waiters
+	for i := uint32(0); i < 5; i++ {
+		it.Release()
+	}
+	// Check internal state
+	if it.quota != 5 {
+		t.Fatalf("expected 5 quota: %v", it.quota)
+	}
+	if len(it.waiters) != 0 {
+		t.Fatalf("expected waiters to be empty: %v", it.waiters)
+	}
+
+	// Releasing additional slots should have no impact
+	it.Release()
+	if it.quota != 5 {
+		t.Fatalf("expected 5 quota: %v", it.quota)
+	}
+}
+
+// TestQuotaContext checks that we can cancel waiters
+func TestQuotaContext(t *testing.T) {
+	t.Parallel()
+
+	it := newSendQuota(5)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Even with cancelled context Await should return a slot if it's free
+	for i := uint32(0); i < 5; i++ {
+		if err := it.Acquire(ctx); err != nil {
+			t.Fatalf("failed to get slot: %v", err)
+		}
+	}
+	// We should not wait if there is not a free slot
+	if err := it.Acquire(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("should fail if context cancelled: %v", err)
+	}
+}
+
+// TestQuotaLoad tests send quota under load
+func TestQuotaLoad(t *testing.T) {
+	t.Parallel()
+
+	const receiveMax = 20
+	const messageCount = 20000
+	var inFlight atomic.Int64
+
+	it := newSendQuota(receiveMax)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	countErr := make(chan int64)
+	awaitErr := make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(messageCount)
+	for i := uint32(0); i < messageCount; i++ {
+		go func(messageID uint32) {
+			defer wg.Done()
+			if err := it.Acquire(ctx); err != nil {
+				awaitErr <- err
+			}
+			curr := inFlight.Add(1)
+			if curr > receiveMax {
+				countErr <- curr
+			}
+			time.Sleep(time.Duration(rand.Intn(100000)))
+			inFlight.Add(-1)
+			it.Release()
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	for {
+		select {
+		case cnt := <-countErr:
+			t.Fatalf("messages in flight exceeded receive max: %d", cnt)
+		case err := <-awaitErr:
+			t.Fatalf("error awaiting: %v", err)
+		case <-done:
+			return // all good
+		}
+	}
+
+	// Check internal state
+	if it.quota != receiveMax {
+		t.Fatalf("expected quota of %d, got %d", receiveMax, it.quota)
+	}
+	if len(it.waiters) != 0 {
+		t.Fatalf("expected waiters to be empty: %v", it.waiters)
+	}
+}

--- a/paho/store/memory/store.go
+++ b/paho/store/memory/store.go
@@ -69,6 +69,10 @@ func (m *Store) Get(packetID uint16) (io.ReadCloser, error) {
 func (m *Store) Delete(id uint16) error {
 	m.Lock()
 	defer m.Unlock()
+	if _, ok := m.data[id]; !ok {
+		// This could be ignored, but reporting it may help reveal other issues
+		return fmt.Errorf("request to delete packet %d; packet not found", id)
+	}
 	delete(m.data, id)
 	return nil
 }


### PR DESCRIPTION
This is required to avoid potential panic and improve logging.

Also tidied up some of the code that handles completion of the message lifecycle.

Ref issue #179