### PR TITLE
Remove SingleHandlerRouter

### DIFF
--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -296,7 +296,7 @@ func TestBasicPubSub(t *testing.T) {
 		PahoErrors:     logger,
 		ClientConfig: paho.ClientConfig{
 			ClientID: "test",
-			Router: paho.NewSingleHandlerRouter(func(publish *paho.Publish) {
+			Router: paho.NewStandardRouterWithDefault(func(publish *paho.Publish) {
 				mrMu.Lock()
 				defer mrMu.Unlock()
 				messagesReceived = append(messagesReceived, publish)

--- a/autopaho/cmd/rpc/config.go
+++ b/autopaho/cmd/rpc/config.go
@@ -127,7 +127,7 @@ func getCmConfig(cfg config) autopaho.ClientConfig {
 		OnConnectError: func(err error) { fmt.Printf("error whilst attempting connection: %s\n", err) },
 		ClientConfig: paho.ClientConfig{
 			ClientID: cfg.clientID,
-			Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+			Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 				log.Printf("%v+", m)
 			}),
 			OnClientError: func(err error) { fmt.Printf("%s requested disconnect: %s\n", cfg.clientID, err) },

--- a/autopaho/examples/basics/basics.go
+++ b/autopaho/examples/basics/basics.go
@@ -56,8 +56,8 @@ func main() {
 		ClientConfig: paho.ClientConfig{
 			// If you are using QOS 1/2, then it's important to specify a client id (which must be unique)
 			ClientID: clientID,
-			// The Router will receive any inbound messages (SingleHandlerRouter ignores the topic and always calls the function)
-			Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+			// The Router will receive any inbound messages (the router can map for you or just pass messages to a single handler)
+			Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 				fmt.Printf("received message on topic %s; body: %s (retain: %t)\n", m.Topic, m.Payload, m.Retain)
 			}),
 			OnClientError: func(err error) { fmt.Printf("client error: %s\n", err) },

--- a/autopaho/examples/docker/subscriber/main.go
+++ b/autopaho/examples/docker/subscriber/main.go
@@ -64,7 +64,7 @@ func main() {
 		ClientConfig: paho.ClientConfig{
 			ClientID: cfg.clientID,
 			Session:  sessionState,
-			Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+			Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 				h.handle(m)
 			}),
 			OnClientError: func(err error) { fmt.Printf("client error: %s\n", err) },

--- a/autopaho/examples/queue/subscribe.go
+++ b/autopaho/examples/queue/subscribe.go
@@ -52,7 +52,7 @@ func subscribe(ctx context.Context, brokerURL *url.URL, msgCount uint64, ready c
 		// eclipse/paho.golang/paho provides base mqtt functionality, the below config will be passed in for each connection
 		ClientConfig: paho.ClientConfig{
 			ClientID: "TestSub",
-			Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+			Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 				msgNo, err := binary.ReadUvarint(bytes.NewReader(m.Payload))
 				if err != nil {
 					panic(err) // Message corruption or something else is using our topic!

--- a/autopaho/persistence_test.go
+++ b/autopaho/persistence_test.go
@@ -92,7 +92,7 @@ func TestDisconnectAfterOutgoingPublish(t *testing.T) {
 		ClientConfig: paho.ClientConfig{
 			ClientID: "test",
 			Session:  session,
-			Router:   paho.NewSingleHandlerRouter(func(publish *paho.Publish) {}),
+			Router:   paho.NewStandardRouterWithDefault(func(publish *paho.Publish) {}),
 		},
 	}
 
@@ -255,7 +255,7 @@ func TestQueueResume(t *testing.T) {
 		ClientConfig: paho.ClientConfig{
 			ClientID: "test",
 			Session:  session,
-			Router:   paho.NewSingleHandlerRouter(func(publish *paho.Publish) {}),
+			Router:   paho.NewStandardRouterWithDefault(func(publish *paho.Publish) {}),
 		},
 	}
 

--- a/autopaho/queue_test.go
+++ b/autopaho/queue_test.go
@@ -98,7 +98,7 @@ func TestQueuedMessages(t *testing.T) {
 		ClientConfig: paho.ClientConfig{
 			ClientID: "test",
 			Session:  session,
-			Router:   paho.NewSingleHandlerRouter(func(publish *paho.Publish) {}),
+			Router:   paho.NewStandardRouterWithDefault(func(publish *paho.Publish) {}),
 		},
 	}
 

--- a/autopaho/readme.md
+++ b/autopaho/readme.md
@@ -49,8 +49,8 @@ cliCfg := autopaho.ClientConfig{
 	ClientConfig: paho.ClientConfig{
 		// If you are using QOS 1/2, then it's important to specify a client id (which must be unique)
 		ClientID: clientID,
-		// The Router will receive any inbound messages (SingleHandlerRouter ignores the topic and always calls the function)
-		Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+		// The Router will receive any inbound messages (the router can map for you or just pass messages to a single handler)
+		Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 			fmt.Printf("received message on topic %s; body: %s (retain: %t)\n", m.Topic, m.Payload, m.Retain)
 		}),
 		OnClientError: func(err error) { fmt.Printf("client error: %s\n", err) },

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -311,7 +311,7 @@ func TestClientReceiveQoS0(t *testing.T) {
 
 	c := NewClient(ClientConfig{
 		Conn: ts.ClientConn(),
-		Router: NewSingleHandlerRouter(func(p *Publish) {
+		Router: NewStandardRouterWithDefault(func(p *Publish) {
 			assert.Equal(t, "test/0", p.Topic)
 			assert.Equal(t, "test payload", string(p.Payload))
 			assert.Equal(t, byte(0), p.QoS)
@@ -356,7 +356,7 @@ func TestClientReceiveQoS1(t *testing.T) {
 
 	c := NewClient(ClientConfig{
 		Conn: ts.ClientConn(),
-		Router: NewSingleHandlerRouter(func(p *Publish) {
+		Router: NewStandardRouterWithDefault(func(p *Publish) {
 			assert.Equal(t, "test/1", p.Topic)
 			assert.Equal(t, "test payload", string(p.Payload))
 			assert.Equal(t, byte(1), p.QoS)
@@ -402,7 +402,7 @@ func TestClientReceiveQoS2(t *testing.T) {
 
 	c := NewClient(ClientConfig{
 		Conn: ts.ClientConn(),
-		Router: NewSingleHandlerRouter(func(p *Publish) {
+		Router: NewStandardRouterWithDefault(func(p *Publish) {
 			assert.Equal(t, "test/2", p.Topic)
 			assert.Equal(t, "test payload", string(p.Payload))
 			assert.Equal(t, byte(2), p.QoS)
@@ -464,7 +464,7 @@ func TestClientReceiveAndAckInOrder(t *testing.T) {
 	wg.Add(expectedPacketsCount)
 	c := NewClient(ClientConfig{
 		Conn: ts.ClientConn(),
-		Router: NewSingleHandlerRouter(func(p *Publish) {
+		Router: NewStandardRouterWithDefault(func(p *Publish) {
 			defer wg.Done()
 			actualPublishPackets = append(actualPublishPackets, *p.Packet())
 		}),
@@ -545,7 +545,7 @@ func TestManualAcksInOrder(t *testing.T) {
 		Conn:                       ts.ClientConn(),
 		EnableManualAcknowledgment: true,
 	})
-	c.Router = NewSingleHandlerRouter(func(p *Publish) {
+	c.Router = NewStandardRouterWithDefault(func(p *Publish) {
 		defer wg.Done()
 		actualPublishPackets = append(actualPublishPackets, *p.Packet())
 		require.NoError(t, c.Ack(p))

--- a/paho/cmd/chat/main.go
+++ b/paho/cmd/chat/main.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	c := paho.NewClient(paho.ClientConfig{
-		Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+		Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 			log.Printf("%s : %s", m.Properties.User.Get("chatname"), string(m.Payload))
 		}),
 		Conn: conn,

--- a/paho/cmd/rpc/main.go
+++ b/paho/cmd/rpc/main.go
@@ -51,7 +51,7 @@ func listener(server, rTopic, username, password string) {
 		c := paho.NewClient(paho.ClientConfig{
 			Conn: conn,
 		})
-		c.Router = paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+		c.Router = paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 			if m.Properties != nil && m.Properties.CorrelationData != nil && m.Properties.ResponseTopic != "" {
 				log.Printf("Received message with response topic %s and correl id %s\n%s", m.Properties.ResponseTopic, string(m.Properties.CorrelationData), string(m.Payload))
 
@@ -138,7 +138,7 @@ func main() {
 	password := flag.String("password", "", "Password to match username")
 	flag.Parse()
 
-	//paho.SetDebugLogger(log.New(os.Stderr, "RPC: ", log.LstdFlags))
+	// paho.SetDebugLogger(log.New(os.Stderr, "RPC: ", log.LstdFlags))
 
 	listener(*server, *rTopic, *username, *password)
 
@@ -151,7 +151,7 @@ func main() {
 	defer cancel()
 
 	c := paho.NewClient(paho.ClientConfig{
-		Router: paho.NewSingleHandlerRouter(nil),
+		Router: paho.NewStandardRouterWithDefault(nil),
 		Conn:   conn,
 	})
 

--- a/paho/cmd/stdoutsub/main.go
+++ b/paho/cmd/stdoutsub/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	c := paho.NewClient(paho.ClientConfig{
-		Router: paho.NewSingleHandlerRouter(func(m *paho.Publish) {
+		Router: paho.NewStandardRouterWithDefault(func(m *paho.Publish) {
 			msgChan <- m
 		}),
 		Conn: conn,


### PR DESCRIPTION
SingleHandlerRouter did not adhere to the
requirements set out in the router interface
documentation.

Have retained NewSingleHandlerRouter so that
most code should run without modification.

ref #168