### PR TITLE
keepalive=0 -> panic, reject empty brokers

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -222,6 +222,9 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 	if cfg.ConnectTimeout == 0 {
 		cfg.ConnectTimeout = 10 * time.Second
 	}
+	if len(cfg.BrokerUrls) == 0 { // This would cause an infinite loop
+		return nil, errors.New("no server urls provided")
+	}
 	if cfg.Queue == nil {
 		cfg.Queue = memory.New()
 	}

--- a/paho/client.go
+++ b/paho/client.go
@@ -287,13 +287,15 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 		c.serverProps.SharedSubAvailable = ca.Properties.SharedSubAvailable
 	}
 
-	c.debug.Println("received CONNACK, starting PingHandler")
-	c.workers.Add(1)
-	go func() {
-		defer c.workers.Done()
-		defer c.debug.Println("returning from ping handler worker")
-		c.PingHandler.Start(c.Conn, time.Duration(keepalive)*time.Second)
-	}()
+	if keepalive > 0 { // "Keep Alive value of 0 has the effect of turning off..."
+		c.debug.Println("received CONNACK, starting PingHandler")
+		c.workers.Add(1)
+		go func() {
+			defer c.workers.Done()
+			defer c.debug.Println("returning from ping handler worker")
+			c.PingHandler.Start(c.Conn, time.Duration(keepalive)*time.Second)
+		}()
+	}
 
 	c.debug.Println("starting publish packets loop")
 	c.workers.Add(1)


### PR DESCRIPTION
paho would panic if keepalive was 0.
Autopaho would go into infinite loop if
no servers supplied.

ref #160
