### PR TITLE
consistent config structure in autopaho and rename "broker" to "server"

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -25,15 +25,15 @@ import (
 // AutoPaho is a wrapper around github.com/eclipse/paho.golang that simplifies the connection process; it automates
 // connections (retrying until the connection comes up) and will attempt to re-establish the connection if it is lost.
 //
-// The aim is to cover a common requirement (connect to the broker and try to keep the connection up); if your
+// The aim is to cover a common requirement (connect to the server and try to keep the connection up); if your
 // requirements differ then please consider using github.com/eclipse/paho.golang directly (perhaps using the
 // code in this file as a base; a secondary aim is to provide example code!).
 
-// ConnectionDownError Down will be returned when a request is made but the connection to the broker is down
-// Note: It is possible that the connection will drop between the request being made and a response being received in
+// ConnectionDownError Down will be returned when a request is made but the connection to the server is down
+// Note: It is possible that the connection will drop between the request being made and a response being received, in
 // which case a different error will be received (this is only returned if the connection is down at the time the
 // request is made).
-var ConnectionDownError = errors.New("connection with the MQTT broker is currently down")
+var ConnectionDownError = errors.New("connection with the MQTT server is currently down")
 
 // WebSocketConfig enables customisation of the websocket connection
 type WebSocketConfig struct {
@@ -44,7 +44,7 @@ type WebSocketConfig struct {
 // ClientConfig adds a few values, required to manage the connection, to the standard paho.ClientConfig (note that
 // conn will be ignored)
 type ClientConfig struct {
-	BrokerUrls                    []*url.URL  // URL(s) for the broker (schemes supported include 'mqtt' and 'tls')
+	ServerUrls                    []*url.URL  // URL(s) for the MQTT server (schemes supported include 'mqtt' and 'tls')
 	TlsCfg                        *tls.Config // Configuration used when connecting using TLS
 	KeepAlive                     uint16      // Keepalive period in seconds (the maximum time interval that is permitted to elapse between the point at which the Client finishes transmitting one MQTT Control Packet and the point it starts sending the next)
 	CleanStartOnInitialConnection bool        //  Clean Start flag, if true, existing session information will be cleared on the first connection (it will be false for subsequent connections)
@@ -55,6 +55,9 @@ type ClientConfig struct {
 	WebSocketCfg      *WebSocketConfig // Enables customisation of the websocket connection
 
 	Queue queue.Queue // Used to queue up publish messages (if nil an error will be returned if publish could not be transmitted)
+
+	// Depreciated: Use ServerUrls instead (this will be used if ServerUrls is empty). Will be removed in a future release.
+	BrokerUrls []*url.URL
 
 	// AttemptConnection, if provided, will be called to establish a network connection.
 	// The returned `conn` must support thread safe writing; most wrapped net.Conn implementations like tls.Conn
@@ -70,34 +73,26 @@ type ClientConfig struct {
 	PahoDebug  log.Logger // debugger passed to the paho package (will default to NOOPLogger{})
 	PahoErrors log.Logger // error logger passed to the paho package (will default to NOOPLogger{})
 
-	connectUsername string
-	connectPassword []byte
+	ConnectUsername string
+	ConnectPassword []byte
 
-	willTopic           string
-	willPayload         []byte
-	willQos             byte
-	willRetain          bool
-	willPayloadFormat   byte
-	willMessageExpiry   uint32
-	willContentType     string
-	willResponseTopic   string
-	willCorrelationData []byte
+	WillMessage    *paho.WillMessage
+	WillProperties *paho.WillProperties
 
-	// Set with SetConnectPacketConfigurator - called prior to connection allowing customisation of the CONNECT packet
-	connectPacketBuilder func(*paho.Connect) *paho.Connect
+	ConnectPacketBuilder func(*paho.Connect) *paho.Connect // called prior to connection allowing customisation of the CONNECT packet
 
-	// Set with SetDisConnectPacketConfigurator - called prior to disconnection allowing customisation of the DISCONNECT
+	// DisconnectPacketBuilder - called prior to disconnection allowing customisation of the DISCONNECT
 	// packet. If the function returns nil, then no DISCONNECT packet will be passed; if nil a default packet is sent.
-	disConnectPacketBuilder func() *paho.Disconnect
+	DisconnectPacketBuilder func() *paho.Disconnect
 
 	// We include the full paho.ClientConfig in order to simplify moving between the two packages.
 	// Note that Conn will be ignored.
 	paho.ClientConfig
 }
 
-// ConnectionManager manages the connection with the broker and provides thew ability to publish messages
+// ConnectionManager manages the connection with the server and provides the ability to publish messages
 type ConnectionManager struct {
-	cli      *paho.Client  // The client will only be set when the connection is up (only updated within NewBrokerConnection goRoutine)
+	cli      *paho.Client  // The client will only be set when the connection is up (only updated within NewServerConnection goRoutine)
 	connUp   chan struct{} // Channel is closed when the connection is up (only valid if cli == nil; must lock Mu to read)
 	connDown chan struct{} // Channel is closed when the connection is down (only valid if cli != nil; must lock Mu to read)
 	mu       sync.Mutex    // protects all of the above
@@ -114,44 +109,66 @@ type ConnectionManager struct {
 }
 
 // ResetUsernamePassword clears any configured username and password on the client configuration
+//
+// Set ConnectUsername and ConnectPassword directly instead.
 func (cfg *ClientConfig) ResetUsernamePassword() {
-	cfg.connectPassword = []byte{}
-	cfg.connectUsername = ""
+	cfg.ConnectPassword = []byte{}
+	cfg.ConnectUsername = ""
 }
 
 // SetUsernamePassword configures username and password properties for the Connect packets
 // These values are staged in the ClientConfig, and preparation of the Connect packet is deferred.
+//
+// Deprecated: Set ConnectUsername and ConnectPassword directly instead.
 func (cfg *ClientConfig) SetUsernamePassword(username string, password []byte) {
 	if len(username) > 0 {
-		cfg.connectUsername = username
+		cfg.ConnectUsername = username
 	}
 
 	if len(password) > 0 {
-		cfg.connectPassword = password
+		cfg.ConnectPassword = password
 	}
 }
 
 // SetWillMessage configures the Will topic, payload, QOS and Retain facets of the client connection
 // These values are staged in the ClientConfig, for later preparation of the Connect packet.
+//
+// Deprecated: Set WillMessage and WillProperties directly instead.
 func (cfg *ClientConfig) SetWillMessage(topic string, payload []byte, qos byte, retain bool) {
-	cfg.willTopic = topic
-	cfg.willPayload = payload
-	cfg.willQos = qos
-	cfg.willRetain = retain
+	cfg.WillMessage = &paho.WillMessage{
+		Retain:  retain,
+		Payload: payload,
+		Topic:   topic,
+		QoS:     qos,
+	}
+
+	// Default Will Properties will match the values used in previous versions for compatibility
+	willDelayInterval := uint32(2 * cfg.KeepAlive)
+
+	cfg.WillProperties = &paho.WillProperties{
+		// Most of these are nil/empty or defaults until related methods are exposed for configuration
+		WillDelayInterval: &willDelayInterval,
+	}
 }
 
 // SetConnectPacketConfigurator assigns a callback for modification of the Connect packet, called before the connection is opened, allowing the application to adjust its configuration before establishing a connection.
 // This function should be treated as asynchronous, and expected to have no side effects.
+//
+// Deprecated: Set ConnectPacketBuilder directly instead. This function exists for
+// backwards compatibility only (and may be removed in the future).
 func (cfg *ClientConfig) SetConnectPacketConfigurator(fn func(*paho.Connect) *paho.Connect) bool {
-	cfg.connectPacketBuilder = fn
+	cfg.ConnectPacketBuilder = fn
 	return fn != nil
 }
 
 // SetDisConnectPacketConfigurator assigns a callback for the provision of a DISCONNECT packet. By default, a DISCONNECT
 // is sent to the server when Disconnect is called; setting a callback allows a custom packet to be provided, or no
 // packet (by returning nil).
+//
+// Deprecated: Set DisconnectPacketBuilder directly instead. This function exists for
+// backwards compatibility only (and may be removed in the future).
 func (cfg *ClientConfig) SetDisConnectPacketConfigurator(fn func() *paho.Disconnect) {
-	cfg.disConnectPacketBuilder = fn
+	cfg.DisconnectPacketBuilder = fn
 }
 
 // buildConnectPacket constructs a Connect packet for the paho client, based on staged configuration.
@@ -164,36 +181,22 @@ func (cfg *ClientConfig) buildConnectPacket(firstConnection bool) *paho.Connect 
 		CleanStart: cfg.CleanStartOnInitialConnection && firstConnection,
 	}
 
-	if len(cfg.connectUsername) > 0 {
+	if len(cfg.ConnectUsername) > 0 {
 		cp.UsernameFlag = true
-		cp.Username = cfg.connectUsername
+		cp.Username = cfg.ConnectUsername
 	}
 
-	if len(cfg.connectPassword) > 0 {
+	if len(cfg.ConnectPassword) > 0 {
 		cp.PasswordFlag = true
-		cp.Password = cfg.connectPassword
+		cp.Password = cfg.ConnectPassword
 	}
 
-	if len(cfg.willTopic) > 0 && len(cfg.willPayload) > 0 {
-		cp.WillMessage = &paho.WillMessage{
-			Retain:  cfg.willRetain,
-			Payload: cfg.willPayload,
-			Topic:   cfg.willTopic,
-			QoS:     cfg.willQos,
-		}
-
-		// how the broker should wait before considering the client disconnected
-		// hopefully this default is sensible for most applications, tolerating short interruptions
-		willDelayInterval := uint32(2 * cfg.KeepAlive)
-
-		cp.WillProperties = &paho.WillProperties{
-			// Most of these are nil/empty or defaults until related methods are exposed for configuration
-			WillDelayInterval: &willDelayInterval,
-			PayloadFormat:     &cfg.willPayloadFormat,
-			MessageExpiry:     &cfg.willMessageExpiry,
-			ContentType:       cfg.willContentType,
-			ResponseTopic:     cfg.willResponseTopic,
-			CorrelationData:   cfg.willCorrelationData,
+	if cfg.WillMessage != nil {
+		cp.WillMessage = cfg.WillMessage
+		if cfg.WillProperties != nil {
+			cp.WillProperties = cfg.WillProperties
+		} else {
+			cp.WillProperties = &paho.WillProperties{}
 		}
 	}
 
@@ -201,8 +204,8 @@ func (cfg *ClientConfig) buildConnectPacket(firstConnection bool) *paho.Connect 
 		cp.Properties = &paho.ConnectProperties{SessionExpiryInterval: &cfg.SessionExpiryInterval}
 	}
 
-	if cfg.connectPacketBuilder != nil {
-		cp = cfg.connectPacketBuilder(cp)
+	if cfg.ConnectPacketBuilder != nil {
+		cp = cfg.ConnectPacketBuilder(cp)
 	}
 
 	return cp
@@ -221,6 +224,12 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 	}
 	if cfg.ConnectTimeout == 0 {
 		cfg.ConnectTimeout = 10 * time.Second
+	}
+	if len(cfg.ServerUrls) == 0 { // backwards compatibility
+		cfg.ServerUrls = cfg.BrokerUrls
+	}
+	if len(cfg.ServerUrls) == 0 { // This would cause an infinite loop
+		return nil, errors.New("no server urls provided")
 	}
 	if cfg.Queue == nil {
 		cfg.Queue = memory.New()
@@ -260,7 +269,7 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 			cliCfg := cfg
 			cliCfg.OnClientError = eh.onClientError
 			cliCfg.OnServerDisconnect = eh.onServerDisconnect
-			cli, connAck := establishBrokerConnection(innerCtx, cliCfg, firstConnection)
+			cli, connAck := establishServerConnection(innerCtx, cliCfg, firstConnection)
 			if cli == nil {
 				break mainLoop // Only occurs when context is cancelled
 			}
@@ -292,8 +301,8 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 				eh.shutdown() // Prevent any errors triggered by closure of context from reaching user
 				// As the connection is up, we call disconnect to shut things down cleanly
 				dp := &paho.Disconnect{ReasonCode: 0}
-				if cfg.disConnectPacketBuilder != nil {
-					dp = cfg.disConnectPacketBuilder()
+				if cfg.DisconnectPacketBuilder != nil {
+					dp = cfg.DisconnectPacketBuilder()
 				}
 				if dp != nil {
 					if err = c.cli.Disconnect(dp); err != nil {
@@ -301,9 +310,9 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 					}
 				}
 				if ctx.Err() != nil { // If this is due to outer context being cancelled, then this will have happened before the inner one gets cancelled.
-					cfg.Debug.Printf("mainLoop: broker connection handler exiting due to context: %s\n", ctx.Err())
+					cfg.Debug.Printf("mainLoop: server connection handler exiting due to context: %s\n", ctx.Err())
 				} else {
-					cfg.Debug.Printf("mainLoop: broker connection handler exiting due to Disconnect call: %s\n", innerCtx.Err())
+					cfg.Debug.Printf("mainLoop: server connection handler exiting due to Disconnect call: %s\n", innerCtx.Err())
 				}
 				break mainLoop
 			}
@@ -313,7 +322,7 @@ func NewConnection(ctx context.Context, cfg ClientConfig) (*ConnectionManager, e
 			close(c.connDown)
 			c.connUp = make(chan struct{})
 			c.mu.Unlock()
-			cfg.Debug.Printf("mainLoop: connection to broker lost (%s); will reconnect\n", err)
+			cfg.Debug.Printf("mainLoop: connection to server lost (%s); will reconnect\n", err)
 		}
 		cfg.Debug.Println("mainLoop: connection manager has terminated")
 	}()

--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -42,23 +42,23 @@ func TestConnect(t *testing.T) {
 // TestDisconnect confirms that Disconnect closes the connection and exits cleanly
 func TestDisconnect(t *testing.T) {
 	t.Parallel()
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 	serverLogger := paholog.NewTestLogger(t, "testServer:")
 	logger := paholog.NewTestLogger(t, "test:")
 
 	ts := testserver.New(serverLogger)
 
 	type tsConnUpMsg struct {
-		cancelFn func()        // Function to cancel test broker context
-		done     chan struct{} // Will be closed when the test broker has disconnected (and shutdown)
+		cancelFn func()        // Function to cancel test server context
+		done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
 	}
 	var tsDone chan struct{}               // Set on AttemptConnection and closed when that test server connection is done
-	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test broker connection is up
+	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test server connection is up
 	pahoConnUpChan := make(chan struct{})  // When autopaho reports connection is up write to channel will occur
 
 	errCh := make(chan error, 2)
 	config := ClientConfig{
-		BrokerUrls:        []*url.URL{broker},
+		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
@@ -150,23 +150,23 @@ func TestDisconnect(t *testing.T) {
 // TestReconnect confirms that the connection is automatically re-established when lost
 func TestReconnect(t *testing.T) {
 	t.Parallel()
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 	serverLogger := paholog.NewTestLogger(t, "testServer:")
 	logger := paholog.NewTestLogger(t, "test:")
 
 	ts := testserver.New(serverLogger)
 
 	type tsConnUpMsg struct {
-		cancelFn func()        // Function to cancel test broker context
-		done     chan struct{} // Will be closed when the test broker has disconnected (and shutdown)
+		cancelFn func()        // Function to cancel test server context
+		done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
 	}
-	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test broker connection is up
+	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test server connection is up
 	pahoConnUpChan := make(chan struct{})  // When autopaho reports connection is up write to channel will occur
 
 	atCount := 0
 
 	config := ClientConfig{
-		BrokerUrls:        []*url.URL{broker},
+		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
@@ -217,7 +217,7 @@ func TestReconnect(t *testing.T) {
 	select {
 	case <-initialConnUpMsg.done:
 	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting test broker shutdown")
+		t.Fatal("timeout awaiting test server shutdown")
 	}
 
 	// Await reconnection
@@ -239,7 +239,7 @@ func TestReconnect(t *testing.T) {
 	select {
 	case <-secondConnUpMsg.done:
 	case <-time.After(shortDelay):
-		t.Fatal("timeout awaiting second test broker shutdown")
+		t.Fatal("timeout awaiting second test server shutdown")
 	}
 	select {
 	case <-cm.Done():
@@ -251,16 +251,16 @@ func TestReconnect(t *testing.T) {
 // TestBasicPubSub performs pub/sub operations at each QOS level
 func TestBasicPubSub(t *testing.T) {
 	t.Parallel()
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 	serverLogger := paholog.NewTestLogger(t, "testServer:")
 	logger := paholog.NewTestLogger(t, "test:")
 	ts := testserver.New(serverLogger)
 
 	type tsConnUpMsg struct {
-		cancelFn func()        // Function to cancel test broker context
-		done     chan struct{} // Will be closed when the test broker has disconnected (and shutdown)
+		cancelFn func()        // Function to cancel test server context
+		done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
 	}
-	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test broker connection is up
+	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test server connection is up
 	pahoConnUpChan := make(chan struct{})  // When autopaho reports connection is up write to channel will occur
 
 	const expectedMessages = 3
@@ -271,7 +271,7 @@ func TestBasicPubSub(t *testing.T) {
 	atCount := 0
 
 	config := ClientConfig{
-		BrokerUrls:        []*url.URL{broker},
+		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
@@ -398,10 +398,10 @@ func TestBasicPubSub(t *testing.T) {
 
 // TestClientConfig_buildConnectPacket exercises buildConnectPacket checking that options and callbacks are applied
 func TestClientConfig_buildConnectPacket(t *testing.T) {
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 
 	config := ClientConfig{
-		BrokerUrls:                    []*url.URL{broker},
+		ServerUrls:                    []*url.URL{server},
 		KeepAlive:                     5,
 		ConnectRetryDelay:             5 * time.Second,
 		ConnectTimeout:                5 * time.Second,
@@ -430,7 +430,7 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 		t.Errorf("Expected absent/empty password, got: flag=%v password=%v", cp.PasswordFlag, cp.Password)
 	}
 
-	// Set some common parameters
+	// Set some common parameters (using now depreciated functions)
 	config.SetUsernamePassword("testuser", []byte("testpassword"))
 	config.SetWillMessage(fmt.Sprintf("client/%s/state", config.ClientID), []byte("disconnected"), 1, true)
 

--- a/autopaho/cmd/rpc/config.go
+++ b/autopaho/cmd/rpc/config.go
@@ -106,7 +106,7 @@ func getConfig() (config, error) {
 
 func getCmConfig(cfg config) autopaho.ClientConfig {
 	return autopaho.ClientConfig{
-		BrokerUrls:        []*url.URL{cfg.serverURL},
+		ServerUrls:        []*url.URL{cfg.serverURL},
 		KeepAlive:         cfg.keepAlive,
 		ConnectRetryDelay: cfg.connectRetryDelay,
 		ConnectTimeout:    time.Duration(5 * time.Second),

--- a/autopaho/cmd/rpc/main.go
+++ b/autopaho/cmd/rpc/main.go
@@ -124,7 +124,7 @@ func main() {
 	listener(cfg.topic)
 
 	//
-	// Connect to the broker
+	// Connect to the server
 	//
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/autopaho/error.go
+++ b/autopaho/error.go
@@ -39,7 +39,7 @@ func (e *errorHandler) onClientError(err error) {
 }
 
 // onClientError called by the paho library when the server requests a disconnection (for example, as part of a
-// clean broker shutdown). We want to begin attempting to reconnect when this occurs (and pass a detectable error
+// clean server shutdown). We want to begin attempting to reconnect when this occurs (and pass a detectable error
 // to the user)
 func (e *errorHandler) onServerDisconnect(d *paho.Disconnect) {
 	e.handleError(&DisconnectError{err: fmt.Sprintf("server requested disconnect (reason: %d)", d.ReasonCode)})

--- a/autopaho/examples/basics/basics.go
+++ b/autopaho/examples/basics/basics.go
@@ -14,7 +14,7 @@ import (
 	"github.com/eclipse/paho.golang/paho"
 )
 
-const clientID = "PahoGoClient" // Change this to something random if using a public test broker
+const clientID = "PahoGoClient" // Change this to something random if using a public test server
 const topic = "PahoGoTestTopic"
 
 func main() {
@@ -22,20 +22,20 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// We will connect to the Eclipse test broker (note that you may see messages that other users publish)
+	// We will connect to the Eclipse test server (note that you may see messages that other users publish)
 	u, err := url.Parse("mqtt://mqtt.eclipseprojects.io:1883")
 	if err != nil {
 		panic(err)
 	}
 
 	cliCfg := autopaho.ClientConfig{
-		BrokerUrls: []*url.URL{u},
+		ServerUrls: []*url.URL{u},
 		KeepAlive:  20, // Keepalive message should be sent every 20 seconds
 		// CleanStartOnInitialConnection defaults to false. Setting this to true will clear the session on the first connection.
 		CleanStartOnInitialConnection: false,
 		// SessionExpiryInterval - Seconds that a session will survive after disconnection.
 		// It is important to set this because otherwise, any queued messages will be lost if the connection drops and
-		// the broker will not queue messages while it is down. The specific setting will depend upon your needs
+		// the server will not queue messages while it is down. The specific setting will depend upon your needs
 		// (60 = 1 minute, 3600 = 1 hour, 86400 = one day, 0xFFFFFFFE = 136 years, 0xFFFFFFFF = don't expire)
 		SessionExpiryInterval: 60,
 		OnConnectionUp: func(cm *autopaho.ConnectionManager, connAck *paho.Connack) {

--- a/autopaho/examples/docker/publisher/main.go
+++ b/autopaho/examples/docker/publisher/main.go
@@ -18,7 +18,7 @@ import (
 	storefile "github.com/eclipse/paho.golang/paho/store/file"
 )
 
-// Connect to the broker and publish a message periodically
+// Connect to the server and publish a message periodically
 func main() {
 	cfg, err := getConfig()
 	if err != nil {
@@ -41,7 +41,7 @@ func main() {
 	}
 
 	cliCfg := autopaho.ClientConfig{
-		BrokerUrls:                    []*url.URL{cfg.serverURL},
+		ServerUrls:                    []*url.URL{cfg.serverURL},
 		KeepAlive:                     cfg.keepAlive,
 		CleanStartOnInitialConnection: false, // the default
 		SessionExpiryInterval:         60,    // Session remains live 60 seconds after disconnect
@@ -71,7 +71,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Connect to the broker - this will return immediately after initiating the connection process
+	// Connect to the server - this will return immediately after initiating the connection process
 	cm, err := autopaho.NewConnection(ctx, cliCfg)
 	if err != nil {
 		panic(err)

--- a/autopaho/examples/docker/readme.md
+++ b/autopaho/examples/docker/readme.md
@@ -1,11 +1,11 @@
 Docker example
 ==============
 
-This folder contains all that is needed to build an environment with a publisher, broker (mosquitto) and subscriber
+This folder contains all that is needed to build an environment with a publisher, server (mosquitto) and subscriber
 using docker (ideally `docker-compose`). While it provides an end-to-end example its primary purpose is to act as a
 starting point for producing reproducible examples (when logging an issue with the library).
 
-Because the publisher (`pub`), broker (`mosquitto`) and subscriber (`sub`) run in separate containers this setup closely
+Because the publisher (`pub`), server (`mosquitto`) and subscriber (`sub`) run in separate containers this setup closely
 simulates a real deployment. One thing to bear in mind is that the network between the containers is very fast and
 reliable (but there are some techniques that can be used to simulate failures etc).
 

--- a/autopaho/examples/docker/subscriber/main.go
+++ b/autopaho/examples/docker/subscriber/main.go
@@ -1,6 +1,6 @@
 package main
 
-// Connect to the broker, subscribe, and write messages received to a file
+// Connect to the server, subscribe, and write messages received to a file
 
 import (
 	"context"
@@ -43,7 +43,7 @@ func main() {
 	}
 
 	cliCfg := autopaho.ClientConfig{
-		BrokerUrls:                    []*url.URL{cfg.serverURL},
+		ServerUrls:                    []*url.URL{cfg.serverURL},
 		KeepAlive:                     cfg.keepAlive,
 		CleanStartOnInitialConnection: false, // the default
 		SessionExpiryInterval:         60,    // Session remains live 60 seconds after disconnect
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	//
-	// Connect to the broker
+	// Connect to the server
 	//
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/autopaho/examples/queue/main.go
+++ b/autopaho/examples/queue/main.go
@@ -9,8 +9,8 @@ import (
 	"syscall"
 )
 
-const brokerURL = "mqtt://127.0.0.1:1883"
-const testTopic = "testTopic" // We publish all messages to the same topic because the broker should maintain message order
+const serverURL = "mqtt://127.0.0.1:1883"
+const testTopic = "testTopic" // We publish all messages to the same topic because the server should maintain message order
 const msgCount = 10000
 const NotifyEvery = 100
 const timeoutSecs = 60
@@ -24,8 +24,8 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Use a local broker (a simple way to provide this is to use the docker example i.e. `docker compose up mosquitto`)
-	u, err := url.Parse(brokerURL)
+	// Use a local server (a simple way to provide this is to use the docker example i.e. `docker compose up mosquitto`)
+	u, err := url.Parse(serverURL)
 	if err != nil {
 		panic(err)
 	}
@@ -46,7 +46,7 @@ func main() {
 
 	publish(ctx, u, msgCount)
 
-	fmt.Println("messages published") // Note that messages may not have been transmitted to broker at this point
+	fmt.Println("messages published") // Note that messages may not have been transmitted to server at this point
 
 	<-ctx.Done() // Wait for user to trigger exit
 	fmt.Println("signal caught - exiting")

--- a/autopaho/examples/queue/publish.go
+++ b/autopaho/examples/queue/publish.go
@@ -22,9 +22,9 @@ type queueWaitForEmpty interface {
 	WaitForEmpty() chan struct{}
 }
 
-// publish connects to the broker and publishes the requested number of messages
+// publish connects to the server and publishes the requested number of messages
 // The body of each message will be the Varint encoded message count (1 - msgCount)
-func publish(ctx context.Context, brokerURL *url.URL, msgCount uint64) {
+func publish(ctx context.Context, serverURL *url.URL, msgCount uint64) {
 	dropAt := make(map[uint64]bool)
 	for _, i := range disconnectAtCount {
 		dropAt[i] = true
@@ -55,7 +55,7 @@ func publish(ctx context.Context, brokerURL *url.URL, msgCount uint64) {
 
 	cliCfg := autopaho.ClientConfig{
 		Queue:                         q,
-		BrokerUrls:                    []*url.URL{brokerURL},
+		ServerUrls:                    []*url.URL{serverURL},
 		KeepAlive:                     20,   // Keepalive message should be sent every 20 seconds
 		CleanStartOnInitialConnection: true, // Previous tests should not contaminate this one!
 		SessionExpiryInterval:         60,   // If connection drops we want session to remain live whilst we reconnect

--- a/autopaho/examples/queue/readme.md
+++ b/autopaho/examples/queue/readme.md
@@ -2,7 +2,7 @@ Queue
 ===
 
 Users often want to call `Publish` and then move on to other things on the assumption that the message will eventually 
-get to the broker (even if the connection is down at the time the message is sent). This example shows how to implement
+get to the server (even if the connection is down at the time the message is sent). This example shows how to implement
 this with `autopaho`; it sends a large number of QOS1/2 messages and confirms that they are correctly received (using a 
 second connection).
 
@@ -14,7 +14,7 @@ potentially, simulating network outages).
 Note that a linked concept is the MQTT V5 "Receive maximum" functionality. This allows the server to tell the client the
 maximum number of inflight QOS1/2 messages that it will accept. The client then needs to limit inflight messages to 
 comply; this may mean that the client needs to queue messages to avoid exceeding the limit. How this is configured will 
-vary depending upon the broker (with Mosquitto its the `max_inflight_messages` setting and defaults to 20).
+vary depending upon the server (with Mosquitto its the `max_inflight_messages` setting and defaults to 20).
 
 Note that, by default, a memory-based queue is used. This example demonstrates storage on disk thus enabling queued
 messages to survive an application restart.
@@ -29,7 +29,7 @@ Use three consoles; one each for:
 ### Mosquitto
 
 **Note**: Before running this ensure that `mosquitto.conf` contains `persistence true` (this is not in the default 
-config and without it tests that include restarting the broker will fail).
+config and without it tests that include restarting the server will fail).
 
 Change to the `autopaho/examples/docker` folder and run `docker compose up mosquitto` this will start Mosquitto and the
 log will be output. Note that logging significantly impacts performance so if you are testing that edit the 

--- a/autopaho/examples/queue/subscribe.go
+++ b/autopaho/examples/queue/subscribe.go
@@ -12,13 +12,13 @@ import (
 	"github.com/eclipse/paho.golang/paho"
 )
 
-// subscribe connects to the broker and subscribes to the test topic. It then expects to receive
+// subscribe connects to the server and subscribes to the test topic. It then expects to receive
 // msgCount messages each containing the varint encoded message count.
 // Generally messages should be received once and in order, but this is only guaranteed where the message number is even
 // (because publish uses QOS2 for those).
 // ready will be closed when we are ready to receive messages
 // Exists when all expected messages have been received
-func subscribe(ctx context.Context, brokerURL *url.URL, msgCount uint64, ready chan struct{}) {
+func subscribe(ctx context.Context, serverURL *url.URL, msgCount uint64, ready chan struct{}) {
 	var msgRcvCount uint64
 	msgReceived := make(map[uint64]bool, msgCount)
 	allReceived := make(chan struct{})
@@ -26,7 +26,7 @@ func subscribe(ctx context.Context, brokerURL *url.URL, msgCount uint64, ready c
 	ping := make(chan uint64)
 
 	cliCfg := autopaho.ClientConfig{
-		BrokerUrls:                    []*url.URL{brokerURL},
+		ServerUrls:                    []*url.URL{serverURL},
 		KeepAlive:                     20,   // Keepalive message should be sent every 20 seconds
 		CleanStartOnInitialConnection: true, // Previous tests should not contaminate this one!
 		SessionExpiryInterval:         60,   // If connection drops we want session to remain live whilst we reconnect

--- a/autopaho/persistence_test.go
+++ b/autopaho/persistence_test.go
@@ -23,7 +23,7 @@ import (
 // the `PUBLISH` is acknowledged
 func TestDisconnectAfterOutgoingPublish(t *testing.T) {
 	t.Parallel()
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 	serverLogger := paholog.NewTestLogger(t, "testServer:")
 	logger := paholog.NewTestLogger(t, "test:")
 
@@ -45,10 +45,10 @@ func TestDisconnectAfterOutgoingPublish(t *testing.T) {
 	})
 
 	type tsConnUpMsg struct {
-		cancelFn func()        // Function to cancel test broker context
-		done     chan struct{} // Will be closed when the test broker has disconnected (and shutdown)
+		cancelFn func()        // Function to cancel test server context
+		done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
 	}
-	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test broker connection is up
+	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test server connection is up
 	var tsDone chan struct{}               // Set on AttemptConnection and closed when that test server connection is done
 	pahoConnUpChan := make(chan struct{})  // When autopaho reports connection is up write to channel will occur
 
@@ -59,7 +59,7 @@ func TestDisconnectAfterOutgoingPublish(t *testing.T) {
 	defer session.Close()
 	connectCount := 0
 	config := ClientConfig{
-		BrokerUrls:        []*url.URL{broker},
+		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
@@ -186,7 +186,7 @@ func TestDisconnectAfterOutgoingPublish(t *testing.T) {
 // at startup).
 func TestQueueResume(t *testing.T) {
 	t.Parallel()
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 	serverLogger := paholog.NewTestLogger(t, "testServer:")
 	logger := paholog.NewTestLogger(t, "test:")
 
@@ -208,10 +208,10 @@ func TestQueueResume(t *testing.T) {
 	})
 
 	type tsConnUpMsg struct {
-		cancelFn func()        // Function to cancel test broker context
-		done     chan struct{} // Will be closed when the test broker has disconnected (and shutdown)
+		cancelFn func()        // Function to cancel test server context
+		done     chan struct{} // Will be closed when the test server has disconnected (and shutdown)
 	}
-	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test broker connection is up
+	tsConnUpChan := make(chan tsConnUpMsg) // Message will be sent when test server connection is up
 	var tsDone chan struct{}               // Set on AttemptConnection and closed when that test server connection is done
 	pahoConnUpChan := make(chan struct{})  // When autopaho reports connection is up write to channel will occur
 
@@ -222,7 +222,7 @@ func TestQueueResume(t *testing.T) {
 	defer session.Close()
 	connectCount := 0
 	config := ClientConfig{
-		BrokerUrls:        []*url.URL{broker},
+		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,       // Connection should come up very quickly

--- a/autopaho/queue_test.go
+++ b/autopaho/queue_test.go
@@ -25,7 +25,7 @@ import (
 // disconnects during the process).
 func TestQueuedMessages(t *testing.T) {
 	t.Parallel()
-	broker, _ := url.Parse(dummyURL)
+	server, _ := url.Parse(dummyURL)
 	serverLogger := paholog.NewTestLogger(t, "testServer:")
 	logger := paholog.NewTestLogger(t, "test:")
 
@@ -71,7 +71,7 @@ func TestQueuedMessages(t *testing.T) {
 	defer session.Close()
 	connectCount := 0
 	config := ClientConfig{
-		BrokerUrls:        []*url.URL{broker},
+		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: 500 * time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,             // Connection should come up very quickly

--- a/autopaho/readme.md
+++ b/autopaho/readme.md
@@ -15,20 +15,20 @@ The following code demonstrates basic usage; the full code is available under `e
 ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 defer stop()
 
-// We will connect to the Eclipse test broker (note that you may see messages that other users publish)
+// We will connect to the Eclipse test server (note that you may see messages that other users publish)
 u, err := url.Parse("mqtt://mqtt.eclipseprojects.io:1883")
 if err != nil {
 	panic(err)
 }
 
 cliCfg := autopaho.ClientConfig{
-	BrokerUrls: []*url.URL{u},
+	ServerUrls: []*url.URL{u},
 	KeepAlive:  20, // Keepalive message should be sent every 20 seconds
 	// CleanStartOnInitialConnection defaults to false. Setting this to true will clear the session on the first connection.
 	CleanStartOnInitialConnection: false,
 	// SessionExpiryInterval - Seconds that a session will survive after disconnection.
 	// It is important to set this because otherwise, any queued messages will be lost if the connection drops and
-	// the broker will not queue messages while it is down. The specific setting will depend upon your needs
+	// the server will not queue messages while it is down. The specific setting will depend upon your needs
 	// (60 = 1 minute, 3600 = 1 hour, 86400 = one day, 0xFFFFFFFE = 136 years, 0xFFFFFFFF = don't expire)
 	SessionExpiryInterval: 60,
 	OnConnectionUp: func(cm *autopaho.ConnectionManager, connAck *paho.Connack) {
@@ -136,7 +136,7 @@ Note: The logs can be easier fo follow if you comment out the `log_type all` in 
 ## Queue
 
 When publishing a message, there are a number of things that can go wrong; for example:
-* The connection to the broker may drop (or not have even come up before your initial message is ready)
+* The connection to the server may drop (or not have even come up before your initial message is ready)
 * The application might be restarted (but you still want messages previously published to be delivered)
 * `ConnectionManager.Publish` may timeout because you are attempting to publish a lot of messages in a short space of time.
 

--- a/internal/testserver/testserver.go
+++ b/internal/testserver/testserver.go
@@ -20,13 +20,13 @@ import (
 //
 // Testing an MQTT client without a server is difficult, using a real server complicates the setup (e.g. server must
 // be available, how do we simulate disconnection, managing timing of ACKs, etc). A workaround is to implement limited
-// broker functions specifically for testing.
+// MQTT server functions specifically for testing.
 //
 // `paho` goes some way towards this in `server_test.go` but that implementation only returns predetermined packets which
 // makes testing persistence of the session state difficult. This implementation goes further and permits the client
 // to subscribe to messages that it, itself, publishes.
 //
-// To simplify testing of the session state, the test broker will automatically disconnect if it receives messages that
+// To simplify testing of the session state, the test server will automatically disconnect if it receives messages that
 // are one of the following strings:
 //
 // * `CloseOnPublishReceived` - Disconnects when the `PUBLISH` message has been received (before any response) - Warning this will result in a loop if the client resends the message.
@@ -89,7 +89,7 @@ func NewStateInfo(sent *packets.ControlPacket, qos byte, topic string, payload [
 	}
 }
 
-// Instance an instance of the test broker
+// Instance an instance of the test server
 // Note that many variables are not mutex protected (because they are private and only accessed from one goroutine)
 type Instance struct {
 	logger          Logger // Used to output status info to assist with debugging
@@ -138,7 +138,7 @@ func (i *Instance) Connected() bool {
 	return i.connected.Load()
 }
 
-// Connect establishes a connection to the test broker
+// Connect establishes a connection to the test server
 // Note that this can fail!
 // Returns a net.Conn (to pass to paho), a channel that will be closed when connection has shutdown and
 // an error (if any).


### PR DESCRIPTION
The autopaho config was a mix of public fields and private fields with setters. This change makes everything public in line with paho. The setters have been left for compatability.

Also remove the term "broker" because this is not used in the MQTT spec so is likely to be confusing.

Closes #174