### PR TITLE
Queued messages should be removed from the queue if they cannot be parsed

### DIFF
--- a/autopaho/examples/queue/publish.go
+++ b/autopaho/examples/queue/publish.go
@@ -44,11 +44,14 @@ func publish(ctx context.Context, serverURL *url.URL, msgCount uint64) {
 
 	// Previous runs of the test may have left messages queued; remove them!
 	for {
-		err := q.Dequeue()
+		entry, err := q.Peek()
 		if errors.Is(err, queue.ErrEmpty) {
 			break
 		}
 		if err != nil {
+			panic(err)
+		}
+		if err := entry.Remove(); err != nil {
 			panic(err)
 		}
 	}

--- a/autopaho/queue/file/queue_test.go
+++ b/autopaho/queue/file/queue_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,11 +20,7 @@ func TestFileQueue(t *testing.T) {
 	}
 
 	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
-		t.Errorf("expected ErrEmpty, got %s", err)
-	}
-
-	if err := q.Dequeue(); !errors.Is(err, queue.ErrEmpty) {
-		t.Errorf("expected ErrEmpty, got %s", err)
+		t.Fatalf("expected ErrEmpty, got %s", err)
 	}
 
 	queueNotEmpty := make(chan struct{})
@@ -53,37 +51,95 @@ func TestFileQueue(t *testing.T) {
 		}
 		time.Sleep(time.Nanosecond) // Short delay due to file system time resolution
 	}
-	if err := q.Dequeue(); err != nil {
-		t.Fatalf("error dequeue entry: %s", err)
+	// Remove the initial "This is a test" entry
+	if entry, err := q.Peek(); err != nil {
+		t.Fatalf("error peeking test entry: %s", err)
+	} else if err = entry.Remove(); err != nil {
+		t.Fatalf("error dequeue test entry: %s", err)
 	}
 
 	for i := 0; i < 10; i++ {
-		r, err := q.Peek()
+		entry, err := q.Peek()
 		if err != nil {
 			t.Fatalf("error peeking entry %d: %s", i, err)
+		}
+		r, err := entry.Reader()
+		if err != nil {
+			t.Fatalf("error getting reader for entry %d: %s", i, err)
 		}
 		buf := &bytes.Buffer{}
 		if _, err = buf.ReadFrom(r); err != nil {
 			t.Fatalf("error reading entry %d: %s", i, err)
 		}
-		if err = r.Close(); err != nil {
-			t.Fatalf("error closing queue entry %d: %s", i, err)
+		if err = entry.Remove(); err != nil {
+			t.Fatalf("error removing queue entry %d: %s", i, err)
 		}
 
 		expected := []byte(fmt.Sprintf(entryFormat, i))
 		if bytes.Compare(expected, buf.Bytes()) != 0 {
 			t.Fatalf("expected \"%s\", got \"%s\"", expected, buf.Bytes())
 		}
-		if err = q.Dequeue(); err != nil {
-			t.Fatalf("error dequeue entry %d: %s", i, err)
-		}
 	}
 
 	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
 		t.Errorf("expected ErrEmpty, got %s", err)
 	}
+}
 
-	if err := q.Dequeue(); !errors.Is(err, queue.ErrEmpty) {
+// TestLeaveAndError checks that the Leave and Error functions do what is expected
+func TestLeaveAndError(t *testing.T) {
+	testDirectory := t.TempDir()
+	q, err := New(testDirectory, "queueTest-", ".que")
+	if err != nil {
+		t.Fatalf("failed to create queue: %s", err)
+	}
+	q.SetErrorExtension(".corrupt")
+
+	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
+		t.Fatalf("expected ErrEmpty, got %s", err)
+	}
+
+	testEntry := []byte("This is a test")
+	if err := q.Enqueue(bytes.NewReader(testEntry)); err != nil {
+		t.Fatalf("error adding to queue: %s", err)
+	}
+
+	// Peek and leave the entry in the queue
+	if entry, err := q.Peek(); err != nil {
+		t.Fatalf("error peeking test entry: %s", err)
+	} else if err = entry.Leave(); err != nil {
+		t.Fatalf("error leaving test entry: %s", err)
+	}
+
+	// Move entry to error state
+	if entry, err := q.Peek(); err != nil {
+		t.Fatalf("error peeking test entry: %s", err)
+	} else if err = entry.Error(); err != nil {
+		t.Fatalf("error erroring test entry: %s", err)
+	}
+
+	// As the file has been moved to error state is should not be part of the queue
+	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
 		t.Errorf("expected ErrEmpty, got %s", err)
+	}
+
+	// Lets confirm that the .corrupt file was created
+	entries, err := os.ReadDir(testDirectory)
+	if err != nil {
+		t.Fatalf("failed to read testDirectory: %s", err)
+	}
+
+	var found bool
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), ".corrupt") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf(".corrupt file not found in test folder")
 	}
 }

--- a/autopaho/queue/memory/queue_test.go
+++ b/autopaho/queue/memory/queue_test.go
@@ -18,10 +18,6 @@ func TestMemoryQueue(t *testing.T) {
 		t.Errorf("expected ErrEmpty, got %s", err)
 	}
 
-	if err := q.Dequeue(); !errors.Is(err, queue.ErrEmpty) {
-		t.Errorf("expected ErrEmpty, got %s", err)
-	}
-
 	queueNotEmpty := make(chan struct{})
 	go func() {
 		<-q.Wait()
@@ -49,37 +45,71 @@ func TestMemoryQueue(t *testing.T) {
 			t.Fatalf("error adding entry %d: %s", i, err)
 		}
 	}
-	if err := q.Dequeue(); err != nil {
-		t.Fatalf("error dequeue entry: %s", err)
+
+	// Remove the initial "This is a test" entry
+	if entry, err := q.Peek(); err != nil {
+		t.Fatalf("error peeking test entry: %s", err)
+	} else if err = entry.Remove(); err != nil {
+		t.Fatalf("error dequeue test entry: %s", err)
 	}
 
 	for i := 0; i < 10; i++ {
-		r, err := q.Peek()
+		entry, err := q.Peek()
 		if err != nil {
 			t.Fatalf("error peeking entry %d: %s", i, err)
+		}
+		r, err := entry.Reader()
+		if err != nil {
+			t.Fatalf("error getting reader for entry %d: %s", i, err)
 		}
 		buf := &bytes.Buffer{}
 		if _, err = buf.ReadFrom(r); err != nil {
 			t.Fatalf("error reading entry %d: %s", i, err)
 		}
-		if err = r.Close(); err != nil {
-			t.Fatalf("error closing queue entry %d: %s", i, err)
+		if err = entry.Remove(); err != nil {
+			t.Fatalf("error removing queue entry %d: %s", i, err)
 		}
 
 		expected := []byte(fmt.Sprintf(entryFormat, i))
 		if bytes.Compare(expected, buf.Bytes()) != 0 {
 			t.Fatalf("expected \"%s\", got \"%s\"", expected, buf.Bytes())
 		}
-		if err = q.Dequeue(); err != nil {
-			t.Fatalf("error dequeue entry %d: %s", i, err)
-		}
 	}
 
 	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
 		t.Errorf("expected ErrEmpty, got %s", err)
 	}
+}
 
-	if err := q.Dequeue(); !errors.Is(err, queue.ErrEmpty) {
+// TestLeaveAndError checks that the Leave and Error functions do what is expected
+func TestLeaveAndError(t *testing.T) {
+	q := New()
+
+	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
+		t.Fatalf("expected ErrEmpty, got %s", err)
+	}
+
+	testEntry := []byte("This is a test")
+	if err := q.Enqueue(bytes.NewReader(testEntry)); err != nil {
+		t.Fatalf("error adding to queue: %s", err)
+	}
+
+	// Peek and leave the entry in the queue
+	if entry, err := q.Peek(); err != nil {
+		t.Fatalf("error peeking test entry: %s", err)
+	} else if err = entry.Leave(); err != nil {
+		t.Fatalf("error leaving test entry: %s", err)
+	}
+
+	// Move entry to error state
+	if entry, err := q.Peek(); err != nil {
+		t.Fatalf("error peeking test entry: %s", err)
+	} else if err = entry.Error(); err != nil {
+		t.Fatalf("error erroring test entry: %s", err)
+	}
+
+	// As the file has been moved to error state is should not be part of the queue
+	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
 		t.Errorf("expected ErrEmpty, got %s", err)
 	}
 }

--- a/autopaho/queue/queue.go
+++ b/autopaho/queue/queue.go
@@ -9,6 +9,16 @@ var (
 	ErrEmpty = errors.New("empty queue")
 )
 
+// Entry - permits access to a queue entry
+// Users must call one of Leave, Remove, or Error when done with the entry (and before calling Peek again)
+// Note that `Reader()` must noth be called after calling Leave, Remove, or Error
+type Entry interface {
+	Reader() (io.Reader, error) // Provides access to the file contents, subsequent calls may return the same reader
+	Leave() error               // Leave the entry in the queue (same entry will be returned on subsequent calls to Peek).
+	Remove() error              // Remove this entry from the queue. Returns queue.ErrEmpty if queue is empty after operation
+	Error() error               // Flag that this entry has an error (remove from queue, potentially retaining data with error flagged)
+}
+
 // Queue provides the functionality needed to manage queued messages
 type Queue interface {
 	// Wait returns a channel that is closed when there is something in the queue (will return a closed channel if the
@@ -18,9 +28,8 @@ type Queue interface {
 	// Enqueue add item to the queue.
 	Enqueue(p io.Reader) error
 
-	// Peek retrieves the oldest item from the queue (without removing it)
-	Peek() (io.ReadCloser, error)
-
-	// Dequeue removes the oldest item from the queue (without returning it)
-	Dequeue() error
+	// Peek retrieves the oldest item from the queue without removing it
+	// Users must call one of Close, Remove, or Error when done with the entry, and before calling Peek again.
+	// Warning: Peek is not safe for concurrent use (it may return the same Entry leading to unpredictable results)
+	Peek() (Entry, error)
 }


### PR DESCRIPTION
If a queued message was corrupted on the disk then an infinite loop resulted (autopaho continually
attempted to send the same corrupt message). This change moves such messages out of the queue.

closes #193
