### PR TITLE
Handle corrupt files in store

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -477,7 +477,7 @@ connectionLoop:
 
 			// Connection is up, and we have at least one thing to send
 			for {
-				entry, err := c.queue.Peek() // If this succeeds, we MUST call Remove, Error or Leave
+				entry, err := c.queue.Peek() // If this succeeds, we MUST call Remove, Quarantine or Leave
 				if errors.Is(err, queue.ErrEmpty) {
 					c.debug.Println("everything in queue transmitted")
 					continue queueLoop
@@ -493,8 +493,8 @@ connectionLoop:
 					c.errors.Printf("error retrieving packet from queue: %s", err)
 					// If the packet cannot be processed, then we need to remove it from the queue
 					// (ideally into an error queue).
-					if err := entry.Error(); err != nil {
-						c.errors.Printf("error moving queue entry to error state: %s", err)
+					if err := entry.Quarantine(); err != nil {
+						c.errors.Printf("error moving queue entry to quarantine: %s", err)
 					}
 					continue
 				}
@@ -502,8 +502,8 @@ connectionLoop:
 				pub, ok := p.Content.(*packets.Publish)
 				if !ok {
 					c.errors.Printf("packet from queue is not a Publish")
-					if qErr := entry.Error(); qErr != nil {
-						c.errors.Printf("error moving queue entry to error state: %s", err)
+					if qErr := entry.Quarantine(); qErr != nil {
+						c.errors.Printf("error moving queue entry to quarantine: %s", err)
 					}
 					continue
 				}

--- a/autopaho/queue/file/queue_test.go
+++ b/autopaho/queue/file/queue_test.go
@@ -93,7 +93,6 @@ func TestLeaveAndError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create queue: %s", err)
 	}
-	q.SetErrorExtension(".corrupt")
 
 	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
 		t.Fatalf("expected ErrEmpty, got %s", err)
@@ -114,7 +113,7 @@ func TestLeaveAndError(t *testing.T) {
 	// Move entry to error state
 	if entry, err := q.Peek(); err != nil {
 		t.Fatalf("error peeking test entry: %s", err)
-	} else if err = entry.Error(); err != nil {
+	} else if err = entry.Quarantine(); err != nil {
 		t.Fatalf("error erroring test entry: %s", err)
 	}
 
@@ -134,7 +133,7 @@ func TestLeaveAndError(t *testing.T) {
 		if entry.IsDir() {
 			continue
 		}
-		if strings.HasSuffix(entry.Name(), ".corrupt") {
+		if strings.HasSuffix(entry.Name(), corruptExtension) {
 			found = true
 			break
 		}

--- a/autopaho/queue/memory/queue.go
+++ b/autopaho/queue/memory/queue.go
@@ -101,9 +101,9 @@ func (q *Queue) Remove() error {
 	return q.remove()
 }
 
-// Error implements Entry.Error - Flag that this entry has an error (remove from queue, potentially retaining data with error flagged)
-func (q *Queue) Error() error {
-	return q.remove() // No way for us to flag an error so we just remove the item from the queue
+// Quarantine implements Entry.Quarantine - Flag that this entry has an error (remove from queue, potentially retaining data with error flagged)
+func (q *Queue) Quarantine() error {
+	return q.remove() // No way for us to actually quarantine this, so we just remove the item from the queue
 }
 
 // remove removes the first item in the queue.

--- a/autopaho/queue/memory/queue_test.go
+++ b/autopaho/queue/memory/queue_test.go
@@ -81,8 +81,8 @@ func TestMemoryQueue(t *testing.T) {
 	}
 }
 
-// TestLeaveAndError checks that the Leave and Error functions do what is expected
-func TestLeaveAndError(t *testing.T) {
+// TestLeaveAndQuarantine checks that the Leave and Quarantine functions do what is expected
+func TestLeaveAndQuarantine(t *testing.T) {
 	q := New()
 
 	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
@@ -101,14 +101,14 @@ func TestLeaveAndError(t *testing.T) {
 		t.Fatalf("error leaving test entry: %s", err)
 	}
 
-	// Move entry to error state
+	// Quarantine entry
 	if entry, err := q.Peek(); err != nil {
 		t.Fatalf("error peeking test entry: %s", err)
-	} else if err = entry.Error(); err != nil {
+	} else if err = entry.Quarantine(); err != nil {
 		t.Fatalf("error erroring test entry: %s", err)
 	}
 
-	// As the file has been moved to error state is should not be part of the queue
+	// As the file has been moved to quarantine it should not be part of the queue
 	if _, err := q.Peek(); !errors.Is(err, queue.ErrEmpty) {
 		t.Errorf("expected ErrEmpty, got %s", err)
 	}

--- a/autopaho/queue/queue.go
+++ b/autopaho/queue/queue.go
@@ -10,13 +10,13 @@ var (
 )
 
 // Entry - permits access to a queue entry
-// Users must call one of Leave, Remove, or Error when done with the entry (and before calling Peek again)
-// Note that `Reader()` must noth be called after calling Leave, Remove, or Error
+// Users must call one of Leave, Remove, or Quarantine when done with the entry (and before calling Peek again)
+// `Reader()` must not be called after calling Leave, Remove, or Quarantine (and any Reader previously requestes should be considered invalid)
 type Entry interface {
 	Reader() (io.Reader, error) // Provides access to the file contents, subsequent calls may return the same reader
 	Leave() error               // Leave the entry in the queue (same entry will be returned on subsequent calls to Peek).
 	Remove() error              // Remove this entry from the queue. Returns queue.ErrEmpty if queue is empty after operation
-	Error() error               // Flag that this entry has an error (remove from queue, potentially retaining data with error flagged)
+	Quarantine() error          // Flag that this entry has an error (remove from queue, potentially retaining data with error flagged)
 }
 
 // Queue provides the functionality needed to manage queued messages
@@ -29,7 +29,7 @@ type Queue interface {
 	Enqueue(p io.Reader) error
 
 	// Peek retrieves the oldest item from the queue without removing it
-	// Users must call one of Close, Remove, or Error when done with the entry, and before calling Peek again.
+	// Users must call one of Close, Remove, or Quarantine when done with the entry, and before calling Peek again.
 	// Warning: Peek is not safe for concurrent use (it may return the same Entry leading to unpredictable results)
 	Peek() (Entry, error)
 }

--- a/autopaho/queue_test.go
+++ b/autopaho/queue_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 	"time"
 
+	memqueue "github.com/eclipse/paho.golang/autopaho/queue/memory"
 	"github.com/eclipse/paho.golang/internal/testserver"
 	"github.com/eclipse/paho.golang/packets"
 	"github.com/eclipse/paho.golang/paho"
 	paholog "github.com/eclipse/paho.golang/paho/log"
 	"github.com/eclipse/paho.golang/paho/session/state"
+	memstore "github.com/eclipse/paho.golang/paho/store/memory"
 )
 
 //
@@ -63,18 +65,32 @@ func TestQueuedMessages(t *testing.T) {
 
 	var allowConnection atomic.Bool
 
+	// Add a corrupt item to the queue (zero bytes) - this should be logged and ignored
+	q := memqueue.New()
+	if err := q.Enqueue(bytes.NewReader(nil)); err != nil {
+		t.Fatalf("failed to add corrupt zero byte item to queue")
+	}
+
 	// custom session because we don't want the client to close it when the connection is lost
 	var tsDone chan struct{} // Set on AttemptConnection and closed when that test server connection is done
-	session := state.NewInMemory()
+	clientStore := memstore.New()
+	serverStore := memstore.New()
+	session := state.New(clientStore, serverStore)
 	session.SetErrorLogger(paholog.NewTestLogger(t, "sessionError:"))
 	session.SetDebugLogger(paholog.NewTestLogger(t, "sessionDebug:"))
 	defer session.Close()
+
+	// Add a corrupt item to the store (zero bytes) - this should be logged and ignored
+	clientStore.Put(1, packets.PUBLISH, bytes.NewReader(nil))
+	serverStore.Put(1, packets.PUBREC, bytes.NewReader(nil))
+
 	connectCount := 0
 	config := ClientConfig{
 		ServerUrls:        []*url.URL{server},
 		KeepAlive:         60,
 		ConnectRetryDelay: 500 * time.Millisecond, // Retry connection very quickly!
 		ConnectTimeout:    shortDelay,             // Connection should come up very quickly
+		Queue:             q,
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			if !allowConnection.Load() {
 				return nil, fmt.Errorf("some random error")
@@ -91,6 +107,7 @@ func TestQueuedMessages(t *testing.T) {
 			}
 		},
 		Debug:                         logger,
+		Errors:                        logger,
 		PahoDebug:                     logger,
 		PahoErrors:                    logger,
 		CleanStartOnInitialConnection: false, // Want session to stay up (this is the default)

--- a/internal/testserver/testserver.go
+++ b/internal/testserver/testserver.go
@@ -257,6 +257,11 @@ func (i *Instance) processIncoming(cp *packets.ControlPacket, out chan<- *packet
 		p := cp.Content.(*packets.Connect)
 		response := packets.NewControlPacket(packets.CONNACK)
 
+		i.sessionExpiryInterval = 0
+		if p.Properties.SessionExpiryInterval != nil {
+			i.sessionExpiryInterval = *p.Properties.SessionExpiryInterval
+		}
+
 		// Session is only retained if there was one (i.sessionExpiryInterval) and connect does not clean it
 		if i.sessionExpiryInterval == 0 || p.CleanStart == true {
 			i.subscriptions = make(map[string]subscription)
@@ -271,10 +276,6 @@ func (i *Instance) processIncoming(cp *packets.ControlPacket, out chan<- *packet
 			for mid := range i.serverSessionState {
 				i.serverMIDs.Allocate(mid)
 			}
-		}
-		i.sessionExpiryInterval = 0
-		if p.Properties.SessionExpiryInterval != nil {
-			i.sessionExpiryInterval = *p.Properties.SessionExpiryInterval
 		}
 		// We return whatever session expiry interval was requested
 		response.Content.(*packets.Connack).Properties = &packets.Properties{

--- a/paho/session/state/store.go
+++ b/paho/session/state/store.go
@@ -9,6 +9,12 @@ type storer interface {
 	Put(packetID uint16, packetType byte, w io.WriterTo) error // Store the packet
 	Get(packetID uint16) (io.ReadCloser, error)                // Retrieve the packet with the specified in ID
 	Delete(id uint16) error                                    // Removes the message with the specified store ID
-	List() ([]uint16, error)                                   // Returns packet IDs in the order they were Put
-	Reset() error                                              // Clears the store (deleting all messages)
+
+	// Quarantine sets the message with the specified store ID into an error state; this may mean deleting it or storing
+	// it somewhere separate. This is intended for use when a corrupt packet is detected (as this may result in data
+	// loss, it's beneficial to have access to corrupt packets for analysis).
+	Quarantine(id uint16) error
+
+	List() ([]uint16, error) // Returns packet IDs in the order they were Put
+	Reset() error            // Clears the store (deleting all messages)
 }

--- a/paho/store/file/store_test.go
+++ b/paho/store/file/store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/eclipse/paho.golang/packets"
@@ -110,6 +111,26 @@ func TestFileStoreNaming(t *testing.T) {
 	if entries[0].Name() != "BlahXX1.txt" {
 		t.Fatalf("filename not as expected; got %s", entries[0].Name())
 	}
+
+	if err := s.Quarantine(1); err != nil {
+		t.Fatalf("failed to Quarantine: %s", err)
+	}
+	entries, err = os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("failed to read dir: %s", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("should be one file; got %#v", entries)
+	}
+	fn := entries[0].Name()
+	if !strings.HasPrefix(fn, "BlahXX1") {
+		t.Fatalf("quarantine filename prefix not as expected; got %s", entries[0].Name())
+	}
+
+	if !strings.HasSuffix(fn, corruptExtension) {
+		t.Fatalf("quarantine filename suffix not as expected; got %s", entries[0].Name())
+	}
+
 }
 
 // TestFileStoreBig creates a fully populated Store and checks things work

--- a/paho/store/memory/store.go
+++ b/paho/store/memory/store.go
@@ -77,6 +77,12 @@ func (m *Store) Delete(id uint16) error {
 	return nil
 }
 
+// Quarantine is called if a corrupt packet is detected.
+// There is little we can do other than deleting the packet.
+func (m *Store) Quarantine(id uint16) error {
+	return m.Delete(id)
+}
+
 // List returns packet IDs in the order they were Put
 func (m *Store) List() ([]uint16, error) {
 	m.Lock()


### PR DESCRIPTION
A corrupt file in the store should be ignored
(quarantined if possible) to avoid either
preventing the connection completing or an
infinite loop.

Also added test and modified queue for
consistency.

closes #195