### PR TITLE
pass `*url.URL` to ConnectPacketBuilder

### DIFF
--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -413,7 +413,7 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 	}
 
 	// Validate initial state
-	cp := config.buildConnectPacket(true)
+	cp := config.buildConnectPacket(true, nil)
 
 	if !cp.CleanStart {
 		t.Errorf("Expected Clean Start to be true")
@@ -434,7 +434,7 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 	config.SetUsernamePassword("testuser", []byte("testpassword"))
 	config.SetWillMessage(fmt.Sprintf("client/%s/state", config.ClientID), []byte("disconnected"), 1, true)
 
-	cp = config.buildConnectPacket(false)
+	cp = config.buildConnectPacket(false, nil)
 	if cp.CleanStart {
 		t.Errorf("Expected Clean Start to be false")
 	}
@@ -476,10 +476,34 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 		return c
 	})
 
-	cp = config.buildConnectPacket(false)
+	testUrl, _ := url.Parse("mqtt://mqtt_user:mqtt_pass@127.0.0.1:1883")
+	cp = config.buildConnectPacket(false, testUrl)
 
 	if *(cp.WillProperties.WillDelayInterval) != 200 { // verifies the override
 		t.Errorf("Will message Delay Interval did not match expected [200]: found [%v]", *(cp.Properties.WillDelayInterval))
 	}
+}
 
+// Example of using ConnectPacketBuilder to extract server password from URL
+func ExampleClientConfig_ConnectPacketBuilder() {
+	serverURL, _ := url.Parse("mqtt://mqtt_user:mqtt_pass@127.0.0.1:1883")
+	config := ClientConfig{
+		ServerUrls:        []*url.URL{serverURL},
+		ConnectRetryDelay: 5 * time.Second,
+		ConnectTimeout:    5 * time.Second,
+		ClientConfig: paho.ClientConfig{
+			ClientID: "test",
+		},
+	}
+	config.ConnectPacketBuilder = func(c *paho.Connect, u *url.URL) *paho.Connect {
+		// Extracting password from URL
+		c.Username = u.User.Username()
+		// up to user to catch empty password passed via URL
+		p, _ := u.User.Password()
+		c.Password = []byte(p)
+		return c
+	}
+	cp := config.buildConnectPacket(false, serverURL)
+	fmt.Printf("user: %s, pass: %s", cp.Username, string(cp.Password))
+	// Output: user: mqtt_user, pass: mqtt_pass
 }

--- a/autopaho/net.go
+++ b/autopaho/net.go
@@ -65,7 +65,7 @@ func establishServerConnection(ctx context.Context, cfg ClientConfig, firstConne
 					cli.SetErrorLogger(cfg.PahoErrors)
 				}
 
-				cp := cfg.buildConnectPacket(firstConnection)
+				cp := cfg.buildConnectPacket(firstConnection, u)
 				connack, err = cli.Connect(connectionCtx, cp) // will return an error if the connection is unsuccessful (checks the reason code)
 				if err == nil {                               // Successfully connected
 					cancelConnCtx()


### PR DESCRIPTION
As per discussion in #192 I've added URL as a parameter, and also an example on how to use it to extract password from URL
