### PR TITLE
paho `Client.ClientConfig` is now private

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -448,7 +448,7 @@ func (c *ConnectionManager) PublishViaQueue(ctx context.Context, p *QueuePublish
 func (c *ConnectionManager) TerminateConnectionForTest() {
 	c.mu.Lock()
 	if c.cli != nil {
-		_ = c.cli.Conn.Close()
+		c.cli.TerminateConnectionForTest()
 	}
 	c.mu.Unlock()
 }

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -23,9 +23,9 @@ func TestNewClient(t *testing.T) {
 	c := NewClient(ClientConfig{})
 
 	require.NotNil(t, c)
-	require.NotNil(t, c.Session)
-	require.NotNil(t, c.Router)
-	require.NotNil(t, c.PingHandler)
+	require.NotNil(t, c.config.Session)
+	require.NotNil(t, c.config.Router)
+	require.NotNil(t, c.config.PingHandler)
 
 	assert.Equal(t, uint16(65535), c.serverProps.ReceiveMaximum)
 	assert.Equal(t, uint8(2), c.serverProps.MaximumQoS)
@@ -41,7 +41,7 @@ func TestNewClient(t *testing.T) {
 	assert.Equal(t, uint32(0), c.clientProps.MaximumPacketSize)
 	assert.Equal(t, uint16(0), c.clientProps.TopicAliasMaximum)
 
-	assert.Equal(t, 10*time.Second, c.PacketTimeout)
+	assert.Equal(t, 10*time.Second, c.config.PacketTimeout)
 }
 
 func TestClientConnect(t *testing.T) {
@@ -116,9 +116,9 @@ func TestClientSubscribe(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	s := &Subscribe{
 		Subscriptions: []SubscribeOptions{
@@ -161,9 +161,9 @@ func TestClientUnsubscribe(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	u := &Unsubscribe{
 		Topics: []string{
@@ -199,9 +199,9 @@ func TestClientPublishQoS0(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	p := &Publish{
 		Topic:   "test/0",
@@ -241,9 +241,9 @@ func TestClientPublishQoS1(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	p := &Publish{
 		Topic:   "test/1",
@@ -286,9 +286,9 @@ func TestClientPublishQoS2(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	p := &Publish{
 		Topic:   "test/2",
@@ -333,9 +333,9 @@ func TestClientReceiveQoS0(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 	go c.routePublishPackets()
 
 	err := ts.SendPacket(&packets.Publish{
@@ -380,9 +380,9 @@ func TestClientReceiveQoS1(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 	go c.routePublishPackets()
 
 	err := ts.SendPacket(&packets.Publish{
@@ -428,9 +428,9 @@ func TestClientReceiveQoS2(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 	go c.routePublishPackets()
 
 	err := ts.SendPacket(&packets.Publish{
@@ -645,9 +645,9 @@ func TestReceiveServerDisconnect(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	err := ts.SendPacket(&packets.Disconnect{
 		ReasonCode: packets.DisconnectServerShuttingDown,
@@ -686,9 +686,9 @@ func TestAuthenticate(t *testing.T) {
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.PingHandler.Start(c.Conn, 30*time.Second)
+		c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
 	}()
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	ctx, cf := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cf()

--- a/paho/extensions/rpc/rpc.go
+++ b/paho/extensions/rpc/rpc.go
@@ -23,7 +23,7 @@ func NewHandler(ctx context.Context, c *paho.Client) (*Handler, error) {
 		correlData: make(map[string]chan *paho.Publish),
 	}
 
-	responseTopic := fmt.Sprintf("%s/responses", c.ClientID)
+	responseTopic := fmt.Sprintf("%s/responses", c.ClientID())
 	c.AddOnPublishReceived(func(pr paho.PublishReceived) (bool, error) {
 		if pr.Packet.Topic == responseTopic {
 			h.responseHandler(pr.Packet)
@@ -34,7 +34,7 @@ func NewHandler(ctx context.Context, c *paho.Client) (*Handler, error) {
 
 	_, err := c.Subscribe(ctx, &paho.Subscribe{
 		Subscriptions: []paho.SubscribeOptions{
-			{Topic: fmt.Sprintf("%s/responses", c.ClientID), QoS: 1},
+			{Topic: fmt.Sprintf("%s/responses", c.ClientID()), QoS: 1},
 		},
 	})
 	if err != nil {
@@ -72,7 +72,7 @@ func (h *Handler) Request(ctx context.Context, pb *paho.Publish) (*paho.Publish,
 	}
 
 	pb.Properties.CorrelationData = []byte(cID)
-	pb.Properties.ResponseTopic = fmt.Sprintf("%s/responses", h.c.ClientID)
+	pb.Properties.ResponseTopic = fmt.Sprintf("%s/responses", h.c.ClientID())
 	pb.Retain = false
 
 	_, err := h.c.Publish(ctx, pb)

--- a/paho/packet_ids_test.go
+++ b/paho/packet_ids_test.go
@@ -31,8 +31,8 @@ func TestPackedIdNoExhaustion(t *testing.T) {
 	c.stop = make(chan struct{})
 	c.publishPackets = make(chan *packets.Publish)
 	go c.incoming()
-	go c.PingHandler.Start(c.Conn, 30*time.Second)
-	c.Session.ConAckReceived(c.Conn, &packets.Connect{}, &packets.Connack{})
+	go c.config.PingHandler.Start(c.config.Conn, 30*time.Second)
+	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	for i := 0; i < 70000; i++ {
 		p := &Publish{


### PR DESCRIPTION
Users could previously access/change the ClientConfig held by `paho.Client`; this invited race conditions (`paho.Client` could use values from the config at any time and no locking mechanism was provided).

To avoid this, the config is now private and examples etc have been updated. A getter for `ClientID` has been added (as this was needed in examples); I suspect additional getters may be of benefit (but will await feedback for that).

This may break some users code (but that is probably a good thing)

closes #210 
