### PR TITLE
Tidy up Mu, termination process and keep alive

### DIFF
--- a/autopaho/examples/docker/publisher/main.go
+++ b/autopaho/examples/docker/publisher/main.go
@@ -127,9 +127,9 @@ func main() {
 					Payload: msg,
 				})
 				if err != nil {
-					fmt.Printf("error publishing: %s\n", err)
+					fmt.Printf("error publishing message %s: %s\n", msg, err)
 				} else if pr.ReasonCode != 0 && pr.ReasonCode != 16 { // 16 = Server received message but there are no subscribers
-					fmt.Printf("reason code %d received\n", pr.ReasonCode)
+					fmt.Printf("reason code %d received for message %s\n", pr.ReasonCode, msg)
 				} else if cfg.printMessages {
 					fmt.Printf("sent message: %s\n", msg)
 				}

--- a/paho/client.go
+++ b/paho/client.go
@@ -72,9 +72,8 @@ type (
 		Session          session.SessionManager
 		autoCloseSession bool
 
-		AuthHandler   Auther
-		PingHandler   Pinger
-		defaultPinger bool
+		AuthHandler Auther
+		PingHandler Pinger
 
 		// Router - new inbound messages will be passed to the `Route(*packets.Publish)` function.
 		//
@@ -112,7 +111,6 @@ type (
 	}
 	// Client is the struct representing an MQTT client
 	Client struct {
-		mu     sync.Mutex
 		config ClientConfig
 
 		// OnPublishReceived copy of OnPublishReceived from ClientConfig (perhaps with added callback form Router)
@@ -120,10 +118,16 @@ type (
 		onPublishReceivedTracker []int // Used to track positions in above
 		onPublishReceivedMu      sync.Mutex
 
-		// authResponse is used for handling the MQTTv5 authentication exchange.
+		// authResponse is used for handling the MQTTv5 authentication exchange (MUST be buffered)
 		authResponse   chan<- packets.ControlPacket
-		stop           chan struct{}
-		done           chan struct{} // closed when shutdown complete (only valid after Connect returns nil error)
+		authResponseMu sync.Mutex // protects the above
+
+		cancelFunc func()
+
+		connectCalled   bool       // if true `Connect` has been called and a connection is being managed
+		connectCalledMu sync.Mutex // protects the above
+
+		done           <-chan struct{} // closed when shutdown complete (only valid after Connect returns nil error)
 		publishPackets chan *packets.Publish
 		acksTracker    acksTracker
 		workers        sync.WaitGroup
@@ -202,7 +206,6 @@ func NewClient(conf ClientConfig) *Client {
 	c.onPublishReceivedTracker = make([]int, len(c.onPublishReceived)) // Must have the same number of elements as onPublishReceived
 
 	if c.config.PingHandler == nil {
-		c.config.defaultPinger = true
 		c.config.PingHandler = NewDefaultPinger()
 	}
 	if c.config.OnClientError == nil {
@@ -224,17 +227,29 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 		return nil, fmt.Errorf("client connection is nil")
 	}
 
+	// The connection is in c.config.Conn which is inaccessible to the user.
+	// The end result of `Connect` (possibly some time after it returns) will be to close the connection so calling
+	// Connect twice is invalid.
+	c.connectCalledMu.Lock()
+	if c.connectCalled {
+		c.connectCalledMu.Unlock()
+		return nil, fmt.Errorf("connect must only be called once")
+	}
+	c.connectCalled = true
+	c.connectCalledMu.Unlock()
+
+	// The passed in ctx applies to the connection process only. clientCtx applies to Client (signals
+	clientCtx, cancelFunc := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	cleanup := func() {
-		close(c.stop)
+		cancelFunc()
 		close(c.publishPackets)
 		_ = c.config.Conn.Close()
-		close(c.done)
-		c.mu.Unlock()
+		close(done)
 	}
 
-	c.mu.Lock()
-	c.stop = make(chan struct{})
-	c.done = make(chan struct{})
+	c.cancelFunc = cancelFunc
+	c.done = done
 
 	var publishPacketsSize uint16 = math.MaxUint16
 	if cp.Properties != nil && cp.Properties.ReceiveMaximum != nil {
@@ -314,8 +329,9 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 		return ca, fmt.Errorf("session error: %w", err)
 	}
 
-	// no more possible calls to cleanup(), defer an unlock
-	defer c.mu.Unlock()
+	// the connection is now fully up and a nil error will be returned.
+	// cleanup() must not be called past this point and will be handled by `shutdown`
+	context.AfterFunc(clientCtx, func() { c.shutdown(done) })
 
 	if ca.Properties != nil {
 		if ca.Properties.ServerKeepAlive != nil {
@@ -347,7 +363,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 	go func() {
 		defer c.workers.Done()
 		defer c.debug.Println("returning from ping handler worker")
-		if err := c.config.PingHandler.Run(c.config.Conn, keepalive); err != nil {
+		if err := c.config.PingHandler.Run(clientCtx, c.config.Conn, keepalive); err != nil {
 			go c.error(fmt.Errorf("ping handler error: %w", err))
 		}
 	}()
@@ -367,7 +383,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 	go func() {
 		defer c.workers.Done()
 		defer c.debug.Println("returning from incoming worker")
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 
 	if c.config.EnableManualAcknowledgment {
@@ -386,7 +402,7 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 			t := time.NewTicker(sendAcksInterval)
 			for {
 				select {
-				case <-c.stop:
+				case <-clientCtx.Done():
 					return
 				case <-t.C:
 					c.acksTracker.flush(func(pbs []*packets.Publish) {
@@ -426,6 +442,8 @@ func (c *Client) ack(pb *packets.Publish) {
 	c.config.Session.Ack(pb)
 }
 
+// routePublishPackets listens on c.publishPackets and passes received messages to the handlers
+// terminates when publishPackets closed
 func (c *Client) routePublishPackets() {
 	for pb := range c.publishPackets {
 		// Copy onPublishReceived so lock is only held briefly
@@ -468,13 +486,13 @@ func (c *Client) routePublishPackets() {
 // Disconnect, the Stop channel is closed or there is an error reading
 // a packet from the network connection
 // Closes `c.publishPackets` when done (should be the only thing sending on this channel)
-func (c *Client) incoming() {
+func (c *Client) incoming(ctx context.Context) {
 	defer c.debug.Println("client stopping, incoming stopping")
 	defer close(c.publishPackets)
 
 	for {
 		select {
-		case <-c.stop:
+		case <-ctx.Done():
 			return
 		default:
 			recv, err := packets.ReadPacket(c.config.Conn)
@@ -495,9 +513,14 @@ func (c *Client) incoming() {
 					if c.config.AuthHandler != nil {
 						go c.config.AuthHandler.Authenticated()
 					}
+					c.authResponseMu.Lock()
 					if c.authResponse != nil {
-						c.authResponse <- *recv
+						select { // authResponse must be buffered, and we should only receive 1 AUTH packet a time
+						case c.authResponse <- *recv:
+						default:
+						}
 					}
+					c.authResponseMu.Unlock()
 				case packets.AuthContinueAuthentication:
 					if c.config.AuthHandler != nil {
 						if _, err := c.config.AuthHandler.Authenticate(AuthFromPacketAuth(ap)).Packet().WriteTo(c.config.Conn); err != nil {
@@ -513,14 +536,10 @@ func (c *Client) incoming() {
 					c.config.Session.PacketReceived(recv, c.publishPackets)
 				} else {
 					c.debug.Printf("received QoS%d PUBLISH", pb.QoS)
-					c.mu.Lock()
 					select {
-					case <-c.stop:
-						c.mu.Unlock()
+					case <-ctx.Done():
 						return
-					default:
-						c.publishPackets <- pb
-						c.mu.Unlock()
+					case c.publishPackets <- pb:
 					}
 				}
 			case packets.PUBACK, packets.PUBCOMP, packets.SUBACK, packets.UNSUBACK, packets.PUBREC, packets.PUBREL:
@@ -528,9 +547,14 @@ func (c *Client) incoming() {
 			case packets.DISCONNECT:
 				pd := recv.Content.(*packets.Disconnect)
 				c.debug.Println("received DISCONNECT")
+				c.authResponseMu.Lock()
 				if c.authResponse != nil {
-					c.authResponse <- *recv
+					select { // authResponse must be buffered, and we should only receive 1 AUTH packet a time
+					case c.authResponse <- *recv:
+					default:
+					}
 				}
+				c.authResponseMu.Unlock()
 				c.config.Session.ConnectionLost(pd) // this may impact the session state
 				go func() {
 					if c.config.OnServerDisconnect != nil {
@@ -548,23 +572,17 @@ func (c *Client) incoming() {
 	}
 }
 
+// close terminates the connection and waits for a clean shutdown
+// may be called multiple times (subsequent calls will wait on previously requested shutdown)
 func (c *Client) close() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.cancelFunc() // cleanup handled by AfterFunc defined in Connect
+	<-c.done
+}
 
-	select {
-	case <-c.stop:
-		// already shutting down, return when shutdown complete
-		<-c.done
-		return
-	default:
-	}
-
-	close(c.stop)
-
-	c.debug.Println("client stopped")
-	c.config.PingHandler.Stop()
-	c.debug.Println("ping stopped")
+// shutdown cleanly shutdown the client
+// This should only be called via the AfterFunc in `Connect` (shutdown must not be called more than once)
+func (c *Client) shutdown(done chan<- struct{}) {
+	c.debug.Println("client stop requested")
 	_ = c.config.Conn.Close()
 	c.debug.Println("conn closed")
 	c.acksTracker.reset()
@@ -578,7 +596,7 @@ func (c *Client) close() {
 	c.debug.Println("session updated, waiting on workers")
 	c.workers.Wait()
 	c.debug.Println("workers done")
-	close(c.done)
+	close(done)
 }
 
 // error is called to signify that an error situation has occurred, this
@@ -605,17 +623,17 @@ func (c *Client) serverDisconnect(d *Disconnect) {
 func (c *Client) Authenticate(ctx context.Context, a *Auth) (*AuthResponse, error) {
 	c.debug.Println("client initiated reauthentication")
 	authResp := make(chan packets.ControlPacket, 1)
-	c.mu.Lock()
+	c.authResponseMu.Lock()
 	if c.authResponse != nil {
-		c.mu.Unlock()
+		c.authResponseMu.Unlock()
 		return nil, fmt.Errorf("previous authentication is still in progress")
 	}
 	c.authResponse = authResp
-	c.mu.Unlock()
+	c.authResponseMu.Unlock()
 	defer func() {
-		c.mu.Lock()
+		c.authResponseMu.Lock()
 		c.authResponse = nil
-		c.mu.Unlock()
+		c.authResponseMu.Unlock()
 	}()
 
 	c.debug.Println("sending AUTH")

--- a/paho/client.go
+++ b/paho/client.go
@@ -362,9 +362,6 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 	}
 
 	c.debug.Println("received CONNACK, starting PingHandler")
-	if c.config.defaultPinger { // Debug logger is set after the client is created so need to copy it to pinger
-		c.config.PingHandler.SetDebug(c.debug)
-	}
 	c.workers.Add(1)
 	go func() {
 		defer c.workers.Done()
@@ -1048,6 +1045,9 @@ func (c *Client) SetDebugLogger(l log.Logger) {
 	c.debug = l
 	if c.config.autoCloseSession { // If we created the session store then it should use the same logger
 		c.config.Session.SetDebugLogger(l)
+	}
+	if c.config.defaultPinger { // Debug logger is set after the client is created so need to copy it to pinger
+		c.config.PingHandler.SetDebug(c.debug)
 	}
 }
 

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -122,16 +122,16 @@ func TestClientSubscribe(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -167,16 +167,16 @@ func TestClientUnsubscribe(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -205,16 +205,16 @@ func TestClientPublishQoS0(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -247,16 +247,16 @@ func TestClientPublishQoS1(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -292,16 +292,16 @@ func TestClientPublishQoS2(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -339,16 +339,16 @@ func TestClientReceiveQoS0(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 	go c.routePublishPackets()
@@ -386,16 +386,16 @@ func TestClientReceiveQoS1(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 	go c.routePublishPackets()
@@ -434,16 +434,16 @@ func TestClientReceiveQoS2(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 	go c.routePublishPackets()
@@ -651,16 +651,16 @@ func TestReceiveServerDisconnect(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -692,16 +692,16 @@ func TestAuthenticate(t *testing.T) {
 	defer c.close()
 	c.SetDebugLogger(clientLogger)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
 	c.workers.Add(2)
 	go func() {
 		defer c.workers.Done()
-		c.incoming()
+		c.incoming(clientCtx)
 	}()
 	go func() {
 		defer c.workers.Done()
-		c.config.PingHandler.Run(c.config.Conn, 30)
+		c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	}()
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
@@ -818,17 +818,23 @@ func TestCleanup(t *testing.T) {
 		Conn: ts.ClientConn(),
 	})
 	require.NotNil(t, c)
+	basicClientInitialisation(c)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // canceling to make the client fail on the connection attempt
+	cancel() // cancelling to make the client fail on the connection attempt
 	ca, err := c.Connect(ctx, &Connect{
 		ClientID: "testClient",
 	})
 	require.True(t, errors.Is(err, context.Canceled))
 	require.Nil(t, ca)
 
-	// verify that client was closed properly
-	require.True(t, isChannelClosed(c.stop))
+	// client should have shutdown cleanly (and waited before returning)
+	select {
+	case <-c.Done():
+	default:
+		t.Error("client should be done")
+
+	}
 
 	// verify that it's possible to try again
 	ts.Stop()
@@ -883,6 +889,7 @@ func TestDisconnect(t *testing.T) {
 		Conn: ts.ClientConn(),
 	})
 	require.NotNil(t, c)
+	basicClientInitialisation(c)
 	c.SetDebugLogger(clientLogger)
 	defer c.close()
 
@@ -900,7 +907,14 @@ func TestDisconnect(t *testing.T) {
 
 	err = c.Disconnect(&Disconnect{})
 	require.NoError(t, err)
-	require.True(t, isChannelClosed(c.stop))
+
+	// client should have shutdown cleanly (and waited before returning)
+	select {
+	case <-c.Done():
+	default:
+		t.Error("client should be done")
+
+	}
 
 	// disconnect again should return an error but not block
 	err = c.Disconnect(&Disconnect{})
@@ -1012,17 +1026,6 @@ func TestSendOnClosedChannel(t *testing.T) {
 	c.close()
 }
 
-func isChannelClosed(ch chan struct{}) (closed bool) {
-	defer func() {
-		err, ok := recover().(error)
-		if ok && err.Error() == "send on closed channel" {
-			closed = true
-		}
-	}()
-	ch <- struct{}{}
-	return
-}
-
 // fakeAuth implements the Auther interface to test client.AuthHandler
 type fakeAuth struct{}
 
@@ -1101,4 +1104,15 @@ func TestAddOnPublishReceived(t *testing.T) {
 	require.Equal(t, 3, testOne, "Expected 3")
 	require.Equal(t, 3, testTwo, "Expected 3")
 	require.Equal(t, 1, testThree, "Expected 1")
+}
+
+// basicClientInitialisation initialises a Client that will be used without calling Connect
+// performs the least configuration possible such that calling `close()` will cleanly shutdown
+func basicClientInitialisation(c *Client) context.Context {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	c.cancelFunc = cancelFunc
+	done := make(chan struct{})
+	c.done = done
+	context.AfterFunc(ctx, func() { c.shutdown(done) })
+	return ctx
 }

--- a/paho/packet_ids_test.go
+++ b/paho/packet_ids_test.go
@@ -43,10 +43,10 @@ func TestPackedIdNoExhaustion(t *testing.T) {
 	})
 	require.NotNil(t, c)
 
-	c.stop = make(chan struct{})
+	clientCtx := basicClientInitialisation(c)
 	c.publishPackets = make(chan *packets.Publish)
-	go c.incoming()
-	go c.config.PingHandler.Run(c.config.Conn, 30)
+	go c.incoming(clientCtx)
+	go c.config.PingHandler.Run(clientCtx, c.config.Conn, 30)
 	c.config.Session.ConAckReceived(c.config.Conn, &packets.Connect{}, &packets.Connack{})
 
 	for i := 0; i < 70000; i++ {

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -106,7 +106,7 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 
 			if t.Before(pingDue) {
 				// A Control Packet has been sent since we last checked, meaning the ping can be delayed
-				timer.Reset(t.Sub(pingDue))
+				timer.Reset(pingDue.Sub(t))
 				continue
 			}
 

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -81,8 +81,8 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 	p.mu.Unlock()
 	defer func() {
 		p.mu.Lock()
-		p.mu.Unlock()
 		p.running = false
+		p.mu.Unlock()
 	}()
 
 	interval := time.Duration(keepAlive) * time.Second

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -16,6 +16,7 @@
 package paho
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -26,53 +27,44 @@ import (
 )
 
 type Pinger interface {
-	// Run() starts the pinger. It blocks until the pinger is stopped.
+	// Run starts the pinger. It blocks until the pinger is stopped.
 	// If the pinger stops due to an error, it returns the error.
 	// If the keepAlive is 0, it returns nil immediately.
-	// Run() must be called only once.
-	Run(conn net.Conn, keepAlive uint16) error
+	// Run() may be called multiple times, but only after prior instances have terminated.
+	Run(ctx context.Context, conn net.Conn, keepAlive uint16) error
 
-	// Stop() gracefully stops the pinger.
-	Stop()
-
-	// PacketSent() is called when a packet is sent to the server.
+	// PacketSent is called when a packet is sent to the server.
 	PacketSent()
 
-	// PingResp() is called when a PINGRESP is received from the server.
+	// PingResp is called when a PINGRESP is received from the server.
 	PingResp()
 
-	// SetDebug() sets the logger for debugging.
+	// SetDebug sets the logger for debugging.
 	// It is not thread-safe and must be called before Run() to avoid race conditions.
 	SetDebug(log.Logger)
 }
 
 // DefaultPinger is the default implementation of Pinger.
 type DefaultPinger struct {
-	timer             *time.Timer
-	keepAlive         uint16
-	conn              net.Conn
-	previousPingAcked chan struct{}
-	done              chan struct{}
-	errChan           chan error
-	ackReceived       chan struct{}
-	stopOnce          sync.Once
-	mu                sync.Mutex
-	debug             log.Logger
+	lastPacketSent   time.Time
+	lastPingResponse time.Time
+
+	debug log.Logger
+
+	running bool // Used to prevent concurrent calls to Run
+
+	mu sync.Mutex // Protects all of the above
 }
 
+// NewDefaultPinger creates a DefaultPinger
 func NewDefaultPinger() *DefaultPinger {
-	previousPingAcked := make(chan struct{}, 1)
-	previousPingAcked <- struct{}{} // initial value
 	return &DefaultPinger{
-		previousPingAcked: previousPingAcked,
-		errChan:           make(chan error, 1),
-		done:              make(chan struct{}),
-		ackReceived:       make(chan struct{}, 1),
-		debug:             log.NOOPLogger{},
+		debug: log.NOOPLogger{},
 	}
 }
 
-func (p *DefaultPinger) Run(conn net.Conn, keepAlive uint16) error {
+// Run starts the pinger; blocks until done (either context cancelled or error encountered)
+func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16) error {
 	if keepAlive == 0 {
 		p.debug.Println("Run() returning immediately due to keepAlive == 0")
 		return nil
@@ -81,106 +73,67 @@ func (p *DefaultPinger) Run(conn net.Conn, keepAlive uint16) error {
 		return fmt.Errorf("conn is nil")
 	}
 	p.mu.Lock()
-	if p.timer != nil {
+	if p.running {
 		p.mu.Unlock()
-		return fmt.Errorf("Run() already called")
+		return fmt.Errorf("Run() already in progress")
 	}
-	select {
-	case <-p.done:
-		p.mu.Unlock()
-		return fmt.Errorf("Run() called after stop()")
-	default:
-	}
-	p.keepAlive = keepAlive
-	p.conn = conn
-	p.timer = time.AfterFunc(0, p.sendPingreq) // Immediately send first pingreq
+	p.running = true
 	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.mu.Unlock()
+		p.running = false
+	}()
 
-	return <-p.errChan
-}
+	interval := time.Duration(keepAlive) * time.Second
+	timer := time.NewTimer(0) // Immediately send first pingreq
+	var lastPingSent time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop() // We don't care if the timer has fired
+			return nil
+		case t := <-timer.C:
+			p.mu.Lock()
+			lastPingResponse := p.lastPingResponse
+			pingDue := p.lastPacketSent.Add(interval)
+			p.mu.Unlock()
 
-func (p *DefaultPinger) Stop() {
-	p.stop(nil)
+			if !lastPingSent.IsZero() && lastPingSent.After(lastPingResponse) {
+				p.debug.Printf("DefaultPinger PINGRESP timeout")
+				return fmt.Errorf("PINGRESP timed out")
+			}
+
+			if t.Before(pingDue) {
+				// A Control Packet has been sent since we last checked, meaning the ping can be delayed
+				timer.Reset(t.Sub(pingDue))
+				continue
+			}
+
+			if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(conn); err != nil {
+				p.debug.Printf("DefaultPinger packet write error: %v", err)
+				return fmt.Errorf("failed to send PINGREQ: %w", err)
+			}
+			lastPingSent = time.Now()
+			timer.Reset(interval)
+		}
+	}
 }
 
 func (p *DefaultPinger) PacketSent() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.timer == nil {
-		p.debug.Println("PacketSent() called before Run()")
-		return
-	}
-	select {
-	case <-p.done:
-		p.debug.Println("PacketSent() returning due to done channel")
-		return
-	default:
-	}
-
-	p.debug.Println("PacketSent() resetting timer")
-	p.timer.Reset(time.Duration(p.keepAlive) * time.Second)
+	p.lastPacketSent = time.Now()
 }
 
 func (p *DefaultPinger) PingResp() {
-	select {
-	case p.ackReceived <- struct{}{}:
-	default:
-		p.debug.Println("PingResp() called when ackReceived channel is full")
-		p.stop(fmt.Errorf("received unexpected PINGRESP"))
-	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastPingResponse = time.Now()
 }
 
 func (p *DefaultPinger) SetDebug(debug log.Logger) {
-	p.debug = debug
-}
-
-func (p *DefaultPinger) sendPingreq() {
-	// Wait for previous ping to be acked before sending another
-	select {
-	case <-p.previousPingAcked:
-	case <-p.done:
-		p.debug.Println("sendPingreq() returning before sending PINGREQ due to done channel")
-		return
-	}
-
-	p.debug.Println("sendPingreq() sending PINGREQ packet")
-	if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(p.conn); err != nil {
-		p.stop(fmt.Errorf("failed to send PINGREQ: %w", err))
-		p.debug.Printf("sendPingreq() calling stop() and returning due to packet write error: %v", err)
-		return
-	}
-	p.debug.Println("sendPingreq() sent PINGREQ packet, waiting for PINGRESP")
-	pingrespTimeout := time.NewTimer(time.Duration(p.keepAlive) * time.Second)
-
-	p.PacketSent()
-
-	select {
-	case <-p.done:
-		p.debug.Println("sendPingreq() returning after sending PINGREQ due to done channel")
-	case <-p.ackReceived:
-		p.previousPingAcked <- struct{}{}
-		p.debug.Println("sendPingreq() returning after receiving PINGRESP")
-	case <-pingrespTimeout.C:
-		p.debug.Println("sendPingreq() calling stop() and returning due to PINGRESP timeout")
-		p.stop(fmt.Errorf("PINGRESP timed out"))
-		return
-	}
-
-	// Stop the timer if it hasn't fired yet
-	if !pingrespTimeout.Stop() {
-		<-pingrespTimeout.C
-	}
-}
-
-func (p *DefaultPinger) stop(err error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.debug.Printf("stop() called with error: %v", err)
-	p.stopOnce.Do(func() {
-		if p.timer != nil {
-			p.timer.Stop()
-		}
-		p.errChan <- err
-		close(p.done)
-	})
+	p.debug = debug
 }


### PR DESCRIPTION
* It was unclear what Client.mu protected.
* Using and using contexts to manage shutdown is easier to follow. 
* Reimplement Pinger using Context

Closes #227
Ref #148