### PR TITLE
Remove MaximumQoS property from CONNECT packet

### DIFF
--- a/packets/properties.go
+++ b/packets/properties.go
@@ -807,7 +807,7 @@ var ValidProperties = map[byte]map[byte]struct{}{
 	PropReasonString:           {CONNACK: {}, PUBACK: {}, PUBREC: {}, PUBREL: {}, PUBCOMP: {}, SUBACK: {}, UNSUBACK: {}, DISCONNECT: {}, AUTH: {}},
 	PropReceiveMaximum:         {CONNECT: {}, CONNACK: {}},
 	PropTopicAliasMaximum:      {CONNECT: {}, CONNACK: {}},
-	PropMaximumQOS:             {CONNECT: {}, CONNACK: {}},
+	PropMaximumQOS:             {CONNACK: {}},
 	PropMaximumPacketSize:      {CONNECT: {}, CONNACK: {}},
 	PropUser:                   {CONNECT: {}, CONNACK: {}, PUBLISH: {}, PUBACK: {}, PUBREC: {}, PUBREL: {}, PUBCOMP: {}, SUBSCRIBE: {}, UNSUBSCRIBE: {}, SUBACK: {}, UNSUBACK: {}, DISCONNECT: {}, AUTH: {}},
 }

--- a/packets/properties_test.go
+++ b/packets/properties_test.go
@@ -129,10 +129,6 @@ func TestPropertiess(t *testing.T) {
 		t.Fatalf("'topicAlias' is valid for 'PUBLISH' packets")
 	}
 
-	if !ValidateID(CONNECT, PropMaximumQOS) {
-		t.Fatalf("'maximumQOS' is valid for 'CONNECT' packets")
-	}
-
 	if !ValidateID(CONNACK, PropMaximumQOS) {
 		t.Fatalf("'maximumQOS' is valid for 'CONNACK' packets")
 	}

--- a/paho/client.go
+++ b/paho/client.go
@@ -266,9 +266,6 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 		if cp.Properties.MaximumPacketSize != nil {
 			c.clientProps.MaximumPacketSize = *cp.Properties.MaximumPacketSize
 		}
-		if cp.Properties.MaximumQOS != nil {
-			c.clientProps.MaximumQoS = *cp.Properties.MaximumQOS
-		}
 		if cp.Properties.ReceiveMaximum != nil {
 			c.clientProps.ReceiveMaximum = *cp.Properties.ReceiveMaximum
 		}

--- a/paho/cp_connect.go
+++ b/paho/cp_connect.go
@@ -41,7 +41,6 @@ type (
 		WillDelayInterval     *uint32
 		ReceiveMaximum        *uint16
 		TopicAliasMaximum     *uint16
-		MaximumQOS            *byte
 		MaximumPacketSize     *uint32
 		User                  UserProperties
 		RequestProblemInfo    bool
@@ -62,7 +61,6 @@ func (c *Connect) InitProperties(p *packets.Properties) {
 		RequestProblemInfo:    true,
 		ReceiveMaximum:        p.ReceiveMaximum,
 		TopicAliasMaximum:     p.TopicAliasMaximum,
-		MaximumQOS:            p.MaximumQOS,
 		MaximumPacketSize:     p.MaximumPacketSize,
 		User:                  UserPropertiesFromPacketUser(p.User),
 	}
@@ -137,7 +135,6 @@ func (c *Connect) Packet() *packets.Connect {
 			WillDelayInterval:     c.Properties.WillDelayInterval,
 			ReceiveMaximum:        c.Properties.ReceiveMaximum,
 			TopicAliasMaximum:     c.Properties.TopicAliasMaximum,
-			MaximumQOS:            c.Properties.MaximumQOS,
 			MaximumPacketSize:     c.Properties.MaximumPacketSize,
 			User:                  c.Properties.User.ToPacketProperties(),
 		}


### PR DESCRIPTION
Closes #161

According to [MQTTv5 spec](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901046), Maximum QoS property should not be included in CONNECT packet, but it may be included only in CONNACK packet.

Actually, I included that property in CONNECT and sent it to Mosquitto MQTT server, the connection was refused. 

So, I also think we should remove Maximum QoS property from CONNECT packet in this library.

If you like this, I hope you can review this request.

Best Regards,

note:
I couldn't pass the test by 'make test' command each in this branch and also master with the following message. It seems to not be related to the change of this branch. 

```
queue_test.go:208: timeout awaiting messages
...
FAIL    github.com/eclipse/paho.golang/autopaho 5.632s
```