### PR TITLE
Remove MaximumQoS property from CONNECT packet #161

### DIFF
--- a/packets/properties.go
+++ b/packets/properties.go
@@ -300,11 +300,6 @@ func (i *Properties) Pack(p byte) []byte {
 			writeUint16(*i.TopicAliasMaximum, &b)
 		}
 
-		if i.MaximumQOS != nil {
-			b.WriteByte(PropMaximumQOS)
-			b.WriteByte(*i.MaximumQOS)
-		}
-
 		if i.MaximumPacketSize != nil {
 			b.WriteByte(PropMaximumPacketSize)
 			writeUint32(*i.MaximumPacketSize, &b)
@@ -312,6 +307,11 @@ func (i *Properties) Pack(p byte) []byte {
 	}
 
 	if p == CONNACK {
+		if i.MaximumQOS != nil {
+			b.WriteByte(PropMaximumQOS)
+			b.WriteByte(*i.MaximumQOS)
+		}
+
 		if i.AssignedClientID != "" {
 			b.WriteByte(PropAssignedClientID)
 			writeString(i.AssignedClientID, &b)
@@ -468,11 +468,6 @@ func (i *Properties) PackBuf(p byte) *bytes.Buffer {
 			writeUint16(*i.TopicAliasMaximum, &b)
 		}
 
-		if i.MaximumQOS != nil {
-			b.WriteByte(PropMaximumQOS)
-			b.WriteByte(*i.MaximumQOS)
-		}
-
 		if i.MaximumPacketSize != nil {
 			b.WriteByte(PropMaximumPacketSize)
 			writeUint32(*i.MaximumPacketSize, &b)
@@ -480,6 +475,11 @@ func (i *Properties) PackBuf(p byte) *bytes.Buffer {
 	}
 
 	if p == CONNACK {
+		if i.MaximumQOS != nil {
+			b.WriteByte(PropMaximumQOS)
+			b.WriteByte(*i.MaximumQOS)
+		}
+
 		if i.AssignedClientID != "" {
 			b.WriteByte(PropAssignedClientID)
 			writeString(i.AssignedClientID, &b)
@@ -807,7 +807,7 @@ var ValidProperties = map[byte]map[byte]struct{}{
 	PropReasonString:           {CONNACK: {}, PUBACK: {}, PUBREC: {}, PUBREL: {}, PUBCOMP: {}, SUBACK: {}, UNSUBACK: {}, DISCONNECT: {}, AUTH: {}},
 	PropReceiveMaximum:         {CONNECT: {}, CONNACK: {}},
 	PropTopicAliasMaximum:      {CONNECT: {}, CONNACK: {}},
-	PropMaximumQOS:             {CONNECT: {}, CONNACK: {}},
+	PropMaximumQOS:             {CONNACK: {}},
 	PropMaximumPacketSize:      {CONNECT: {}, CONNACK: {}},
 	PropUser:                   {CONNECT: {}, CONNACK: {}, PUBLISH: {}, PUBACK: {}, PUBREC: {}, PUBREL: {}, PUBCOMP: {}, SUBSCRIBE: {}, UNSUBSCRIBE: {}, SUBACK: {}, UNSUBACK: {}, DISCONNECT: {}, AUTH: {}},
 }

--- a/packets/properties_test.go
+++ b/packets/properties_test.go
@@ -129,10 +129,6 @@ func TestPropertiess(t *testing.T) {
 		t.Fatalf("'topicAlias' is valid for 'PUBLISH' packets")
 	}
 
-	if !ValidateID(CONNECT, PropMaximumQOS) {
-		t.Fatalf("'maximumQOS' is valid for 'CONNECT' packets")
-	}
-
 	if !ValidateID(CONNACK, PropMaximumQOS) {
 		t.Fatalf("'maximumQOS' is valid for 'CONNACK' packets")
 	}

--- a/paho/client.go
+++ b/paho/client.go
@@ -266,9 +266,6 @@ func (c *Client) Connect(ctx context.Context, cp *Connect) (*Connack, error) {
 		if cp.Properties.MaximumPacketSize != nil {
 			c.clientProps.MaximumPacketSize = *cp.Properties.MaximumPacketSize
 		}
-		if cp.Properties.MaximumQOS != nil {
-			c.clientProps.MaximumQoS = *cp.Properties.MaximumQOS
-		}
 		if cp.Properties.ReceiveMaximum != nil {
 			c.clientProps.ReceiveMaximum = *cp.Properties.ReceiveMaximum
 		}

--- a/paho/cp_connect.go
+++ b/paho/cp_connect.go
@@ -41,7 +41,6 @@ type (
 		WillDelayInterval     *uint32
 		ReceiveMaximum        *uint16
 		TopicAliasMaximum     *uint16
-		MaximumQOS            *byte
 		MaximumPacketSize     *uint32
 		User                  UserProperties
 		RequestProblemInfo    bool
@@ -62,7 +61,6 @@ func (c *Connect) InitProperties(p *packets.Properties) {
 		RequestProblemInfo:    true,
 		ReceiveMaximum:        p.ReceiveMaximum,
 		TopicAliasMaximum:     p.TopicAliasMaximum,
-		MaximumQOS:            p.MaximumQOS,
 		MaximumPacketSize:     p.MaximumPacketSize,
 		User:                  UserPropertiesFromPacketUser(p.User),
 	}
@@ -137,7 +135,6 @@ func (c *Connect) Packet() *packets.Connect {
 			WillDelayInterval:     c.Properties.WillDelayInterval,
 			ReceiveMaximum:        c.Properties.ReceiveMaximum,
 			TopicAliasMaximum:     c.Properties.TopicAliasMaximum,
-			MaximumQOS:            c.Properties.MaximumQOS,
 			MaximumPacketSize:     c.Properties.MaximumPacketSize,
 			User:                  c.Properties.User.ToPacketProperties(),
 		}


### PR DESCRIPTION
**Do not create a Pull Request without creating an issue first**
#161 was created related to this request.

**The design of your solution to the problem should be discussed and agreed in an issue before submitting the PR**
According to [MQTTv5 spec](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901046), Maximum QoS property should not be included in CONNECT packet. Actually, when I tried to send CONNECT packet included that property to Mosquitto MQTT server, the connection was refused by Mosquitto. So, I think we should remove Maximum QoS property from CONNECT packet in this library.

note: This request is same with #240, but I remaked the request after some confirmations, because there was a problem with test on my envrionment (#242). As a result, the problem wasn't probably related to this change.

**ECA - Eclipse Contributer Agreement**
had already done

**Testing**
- ```make test``` was passed. I sometimes catched an issue with #242, but tests were passed temporarily with making the timeout of autopaho's cm longer.
- I confirmed almost all parts related to this change with grep ''QOS" or "QoS" (including "MaximumQoS" and "MaximumQOS") just in case.

**Closing issues**
closes #161