### PR TITLE
Add backoff strategy interfaces and implementations

### DIFF
--- a/autopaho/auto_test.go
+++ b/autopaho/auto_test.go
@@ -74,10 +74,10 @@ func TestDisconnect(t *testing.T) {
 
 	errCh := make(chan error, 2)
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                   // Connection should come up very quickly
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			ctx, cancel := context.WithCancel(ctx)
 			conn, done, err := ts.Connect(ctx)
@@ -186,10 +186,10 @@ func TestReconnect(t *testing.T) {
 	pinger.SetDebug(paholog.NewTestLogger(t, "pinger:"))
 
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                   // Connection should come up very quickly
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			atCount += 1
 			if atCount == 2 { // fail on the initial reconnection attempt to exercise retry functionality
@@ -299,10 +299,10 @@ func TestBasicPubSub(t *testing.T) {
 	atCount := 0
 
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                   // Connection should come up very quickly
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			atCount += 1
 			if atCount > 1 { // force failure if a reconnection is attempted (the connection should not drop in this test)
@@ -444,10 +444,10 @@ func TestAuthenticate(t *testing.T) {
 	atCount := 0
 
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                   // Connection should come up very quickly
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			atCount += 1
 			if atCount == 2 { // fail on the initial reconnection attempt to exercise retry functionality
@@ -542,7 +542,7 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 	config := ClientConfig{
 		ServerUrls:                    []*url.URL{server},
 		KeepAlive:                     5,
-		ConnectRetryDelay:             5 * time.Second,
+		ReconnectBackoffStrategy:      NewConstantBackoffStrategy(5 * time.Second),
 		ConnectTimeout:                5 * time.Second,
 		CleanStartOnInitialConnection: true, // Should set Clean Start flag on first connection attempt
 		// extends the lower-level paho.ClientConfig
@@ -627,9 +627,9 @@ func TestClientConfig_buildConnectPacket(t *testing.T) {
 func ExampleClientConfig_ConnectPacketBuilder() {
 	serverURL, _ := url.Parse("mqtt://mqtt_user:mqtt_pass@127.0.0.1:1883")
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{serverURL},
-		ConnectRetryDelay: 5 * time.Second,
-		ConnectTimeout:    5 * time.Second,
+		ServerUrls:               []*url.URL{serverURL},
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(5 * time.Second),
+		ConnectTimeout:           5 * time.Second,
 		ClientConfig: paho.ClientConfig{
 			ClientID: "test",
 		},

--- a/autopaho/backoff.go
+++ b/autopaho/backoff.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ *  and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package autopaho
+
+import (
+	"time"
+)
+
+// The BackoffStrategy is a container for the configuration of a given strategy
+// whereas the returned Backoff is the actual implementation of the strategy.
+//
+// As such BackoffStrategy instances are supposed to be thread safe and freely sharable between users.
+type BackoffStrategy interface {
+	// Returns a configured backoff instance.
+	Backoff() Backoff
+}
+
+// Backoff represents a configured instance of the strategy which computes the
+// next backoff duration.
+//
+// NOTE: Generally instances are NOT supposed to be reused or shared.
+type Backoff interface {
+	// Returns the next backoff duration.
+	Next() time.Duration
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// helper structs for backoff implementations
+////////////////////////////////////////////////////////////////////////////////
+
+// The BackoffDelegate implements the Backoff interface and delegates backoff
+// computation to the internal function property.
+type BackoffDelegate struct {
+	next func() time.Duration
+}
+
+func (b *BackoffDelegate) Next() time.Duration {
+	return b.next()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// implementation for constant backoff
+////////////////////////////////////////////////////////////////////////////////
+
+// The ConstantBackoffStrategy implements the BackoffStrategy interface and
+// provides instances of constant duration.
+//
+// As the duration is constant, the strategy and the actual backoff are thread
+// safe and can be shared.
+type ConstantBackoffStrategy struct {
+	backoff Backoff
+}
+
+func (bs *ConstantBackoffStrategy) Backoff() Backoff {
+	return bs.backoff
+}
+
+// Creates a new ConstantBackoffStrategy with the specified delay.
+func NewConstantBackoffStrategy(delay time.Duration) *ConstantBackoffStrategy {
+	backoff := &BackoffDelegate{
+		next: func() time.Duration {
+			return delay
+		},
+	}
+
+	return &ConstantBackoffStrategy{
+		backoff: backoff,
+	}
+}

--- a/autopaho/backoff_test.go
+++ b/autopaho/backoff_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ *  and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// build +unittest
+
+package autopaho
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestConstantBackoffStrategyNoDelay(t *testing.T) {
+	expected := 0 * time.Second
+
+	noDelayStrategy := NewConstantBackoffStrategy(expected)
+
+	noDelay := noDelayStrategy.Backoff()
+	for i := 0; i < 100; i++ {
+		actual := noDelay.Next()
+		if actual != expected {
+			t.Fatalf("expected value: `%s`, actual `%s`", expected, actual)
+		}
+	}
+}
+
+func TestConstantBackoffStrategyRandomValue(t *testing.T) {
+	for j := 0; j < 10; j++ {
+		nonZero := rand.Intn(100) + 1
+		expected := time.Duration(nonZero) * time.Second
+
+		nonZeroDelayStrategy := NewConstantBackoffStrategy(expected)
+
+		nonZeroDelay := nonZeroDelayStrategy.Backoff()
+		for i := 0; i < 100; i++ {
+			actual := nonZeroDelay.Next()
+			if actual != expected {
+				t.Fatalf("expected value: `%s`, actual `%s`", expected, actual)
+			}
+		}
+	}
+}

--- a/autopaho/examples/backoff/backoff.go
+++ b/autopaho/examples/backoff/backoff.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ *  and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package main
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/eclipse/paho.golang/autopaho"
+)
+
+func main() {
+	// used to calculate the number of iterations
+	const interationBase = 1
+
+	backoffStrategy := autopaho.DefaultExponentialBackoffStrategy()
+
+	backoff := backoffStrategy.Backoff()
+
+	minBackoff := int64(math.MaxInt64)
+	maxBackoff := int64(0)
+	iterationsTotal := 0
+	for i := 0; i < 22; i++ {
+		iterations := interationBase << i
+		for j := 0; j < iterations; j++ {
+			backoffTime := backoff.Next().Milliseconds()
+			if backoffTime < minBackoff {
+				minBackoff = backoffTime
+			}
+			if backoffTime > maxBackoff {
+				maxBackoff = backoffTime
+			}
+		}
+		iterationsTotal += iterations
+
+		fmt.Printf("After % 8d iterations, min: %d, max: % 7d\n", iterationsTotal, minBackoff, maxBackoff)
+	}
+}

--- a/autopaho/examples/docker/publisher/main.go
+++ b/autopaho/examples/docker/publisher/main.go
@@ -60,7 +60,7 @@ func main() {
 		KeepAlive:                     cfg.keepAlive,
 		CleanStartOnInitialConnection: false, // the default
 		SessionExpiryInterval:         60,    // Session remains live 60 seconds after disconnect
-		ConnectRetryDelay:             cfg.connectRetryDelay,
+		ReconnectBackoffStrategy:      autopaho.NewConstantBackoffStrategy(cfg.connectRetryDelay),
 		OnConnectionUp:                func(*autopaho.ConnectionManager, *paho.Connack) { fmt.Println("mqtt connection up") },
 		OnConnectError:                func(err error) { fmt.Printf("error whilst attempting connection: %s\n", err) },
 		Debug:                         log.NOOPLogger{},

--- a/autopaho/examples/docker/subscriber/main.go
+++ b/autopaho/examples/docker/subscriber/main.go
@@ -62,7 +62,7 @@ func main() {
 		KeepAlive:                     cfg.keepAlive,
 		CleanStartOnInitialConnection: false, // the default
 		SessionExpiryInterval:         60,    // Session remains live 60 seconds after disconnect
-		ConnectRetryDelay:             cfg.connectRetryDelay,
+		ReconnectBackoffStrategy:      autopaho.NewConstantBackoffStrategy(cfg.connectRetryDelay),
 		OnConnectionUp: func(cm *autopaho.ConnectionManager, connAck *paho.Connack) {
 			fmt.Println("mqtt connection up")
 			if _, err := cm.Subscribe(context.Background(), &paho.Subscribe{

--- a/autopaho/examples/rpc/main.go
+++ b/autopaho/examples/rpc/main.go
@@ -141,11 +141,11 @@ func main() {
 	}
 
 	genericCfg := autopaho.ClientConfig{
-		ServerUrls:        []*url.URL{serverUrl},
-		KeepAlive:         30,
-		ConnectRetryDelay: 2 * time.Second,
-		ConnectTimeout:    5 * time.Second,
-		OnConnectError:    func(err error) { fmt.Printf("error whilst attempting connection: %s\n", err) },
+		ServerUrls:               []*url.URL{serverUrl},
+		KeepAlive:                30,
+		ReconnectBackoffStrategy: autopaho.NewConstantBackoffStrategy(2 * time.Second),
+		ConnectTimeout:           5 * time.Second,
+		OnConnectError:           func(err error) { fmt.Printf("error whilst attempting connection: %s\n", err) },
 		ClientConfig: paho.ClientConfig{
 			OnClientError: func(err error) { fmt.Printf("requested disconnect: %s\n", err) },
 			OnServerDisconnect: func(d *paho.Disconnect) {

--- a/autopaho/net.go
+++ b/autopaho/net.go
@@ -44,6 +44,7 @@ func establishServerConnection(ctx context.Context, cfg ClientConfig, firstConne
 	// Note: We do not touch b.cli in order to avoid adding thread safety issues.
 	var err error
 
+	backoff := cfg.ReconnectBackoffStrategy.Backoff()
 	for {
 		for _, u := range cfg.ServerUrls {
 			connectionCtx, cancelConnCtx := context.WithTimeout(ctx, cfg.ConnectTimeout)
@@ -106,7 +107,7 @@ func establishServerConnection(ctx context.Context, cfg ClientConfig, firstConne
 
 		// Delay before attempting another connection
 		select {
-		case <-time.After(cfg.ConnectRetryDelay):
+		case <-time.After(backoff.Next()):
 		case <-ctx.Done():
 			return nil, nil
 		}

--- a/autopaho/persistence_test.go
+++ b/autopaho/persistence_test.go
@@ -74,10 +74,10 @@ func TestDisconnectAfterOutgoingPublish(t *testing.T) {
 	defer session.Close()
 	connectCount := 0
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                   // Connection should come up very quickly
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			ctx, cancel := context.WithCancel(ctx) // Note: go vet warning is invalid
 			conn, done, err := ts.Connect(ctx)
@@ -240,10 +240,10 @@ func TestQueueResume(t *testing.T) {
 	defer session.Close()
 	connectCount := 0
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,       // Connection should come up very quickly
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                   // Connection should come up very quickly
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			ctx, cancel := context.WithCancel(ctx) // Note: go vet warning is invalid
 			conn, done, err := ts.Connect(ctx)

--- a/autopaho/queue_test.go
+++ b/autopaho/queue_test.go
@@ -105,11 +105,11 @@ func TestQueuedMessages(t *testing.T) {
 
 	connectCount := 0
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         60,
-		ConnectRetryDelay: 500 * time.Millisecond, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay,             // Connection should come up very quickly
-		Queue:             q,
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                60,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(500 * time.Millisecond), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                                         // Connection should come up very quickly
+		Queue:                    q,
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			if !allowConnection.Load() {
 				return nil, fmt.Errorf("some random error")
@@ -315,11 +315,11 @@ func TestPreloadPublish(t *testing.T) {
 	session.SetDebugLogger(paholog.NewTestLogger(t, "sessionDebug:"))
 	defer session.Close()
 	config := ClientConfig{
-		ServerUrls:        []*url.URL{server},
-		KeepAlive:         0,
-		ConnectRetryDelay: shortDelay, // Retry connection very quickly!
-		ConnectTimeout:    shortDelay, // Connection should come up very quickly
-		Queue:             q,
+		ServerUrls:               []*url.URL{server},
+		KeepAlive:                0,
+		ReconnectBackoffStrategy: NewConstantBackoffStrategy(shortDelay), // Retry connection very quickly!
+		ConnectTimeout:           shortDelay,                             // Connection should come up very quickly
+		Queue:                    q,
 		AttemptConnection: func(ctx context.Context, _ ClientConfig, _ *url.URL) (net.Conn, error) {
 			var conn net.Conn
 			var err error


### PR DESCRIPTION
This PR introduces the ability to use a backoff strategy for reconnect attempts.

As default a backoff strategy is used whichs return the same backoff value mimicking the previous behaviour.
In addition there is an exponential backoff available which will increase the max value on each attempt up to a configurable limit.
The created backoff is a random value between a configured non-zero minimum and the increasing max (up to the configured limit). Using a random value from an increasing range helps spread client reconnect attempts.

**Testing**

Existing code has been changed to use the same duration as before but now uses the constant backoff implementation instead. All tests pass.

Additionally there are dedicated tests for:

- Constant backoff
- Exponential backoff

**Closing issues**

closes #249 `
