### PR TITLE
PublishWithOptions QoS0 return empty PublishRespoonse

### DIFF
--- a/paho/client.go
+++ b/paho/client.go
@@ -874,7 +874,7 @@ func (c *Client) PublishWithOptions(ctx context.Context, p *Publish, o PublishOp
 			return nil, err
 		}
 		c.config.PingHandler.PacketSent()
-		return nil, nil
+		return &PublishResponse{}, nil
 	case 1, 2:
 		return c.publishQoS12(ctx, pb, o)
 	}

--- a/paho/client_test.go
+++ b/paho/client_test.go
@@ -224,8 +224,9 @@ func TestClientPublishQoS0(t *testing.T) {
 		Payload: []byte("test payload"),
 	}
 
-	_, err := c.Publish(context.Background(), p)
+	pr, err := c.Publish(context.Background(), p)
 	require.Nil(t, err)
+	require.NotNil(t, pr)
 
 	time.Sleep(10 * time.Millisecond)
 }


### PR DESCRIPTION
PublishWithOptions may return both nil error and nil PublishResponse when QoS0 is used, which can potentially result in nil pointer exceptions. This commit updates PublishWithOptions to return a pointer to an empty PublishResponse when QoS0 is used to eliminate this risk.

Closes #159
