### PR TITLE
Improve default ping handler

### DIFF
--- a/paho/default_pinger_test.go
+++ b/paho/default_pinger_test.go
@@ -232,6 +232,7 @@ func TestDefaultPingerStartStop(t *testing.T) {
 
 // In case of slow and unstable network connection, the WriteTo operation may block for longer than KeepAlive interval
 func TestDefaultPingerBlockingWriteTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	fakeServerConn, fakeClientConn := net.Pipe()
 	// intentionally do not read from fakeServerConn to simulate a blocking write operation
 	defer fakeServerConn.Close()

--- a/paho/default_pinger_test.go
+++ b/paho/default_pinger_test.go
@@ -25,6 +25,7 @@ import (
 	paholog "github.com/eclipse/paho.golang/paho/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 )
 
 func TestDefaultPingerTimeout(t *testing.T) {
@@ -226,5 +227,53 @@ func TestDefaultPingerStartStop(t *testing.T) {
 		if err != nil {
 			t.Fatal("Second call to Run should succeed (clean cancel should return nil error)")
 		}
+	}
+}
+
+// In case of slow and unstable network connection, the WriteTo operation may block for longer than KeepAlive interval
+func TestDefaultPingerBlockingWriteTimeout(t *testing.T) {
+	fakeServerConn, fakeClientConn := net.Pipe()
+	// intentionally do not read from fakeServerConn to simulate a blocking write operation
+	defer fakeServerConn.Close()
+
+	pinger := NewDefaultPinger()
+	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pingResult := make(chan error, 1)
+	go func() {
+		pingResult <- pinger.Run(ctx, fakeClientConn, 1)
+	}()
+
+	select {
+	case err := <-pingResult:
+		require.NotNil(t, err)
+		assert.EqualError(t, err, "PINGRESP timed out")
+	case <-time.After(10 * time.Second):
+		t.Error("expected DefaultPinger to detect timeout and return error")
+	}
+}
+
+func TestDefaultPingerContextCancelled(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	fakeServerConn, fakeClientConn := net.Pipe()
+	defer fakeServerConn.Close()
+
+	pinger := NewDefaultPinger()
+	pinger.SetDebug(paholog.NewTestLogger(t, "DefaultPinger:"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	pingResult := make(chan error, 1)
+	go func() {
+		pingResult <- pinger.Run(ctx, fakeClientConn, 60)
+	}()
+
+	select {
+	case err := <-pingResult:
+		require.Nil(t, err)
+	case <-time.After(10 * time.Second):
+		t.Error("expected DefaultPinger to exit when context is cancelled")
 	}
 }

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -87,13 +87,14 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 
 	interval := time.Duration(keepAlive) * time.Second
 	timer := time.NewTimer(0) // Immediately send first pingreq
+	// If timer is not stopped, it cannot be garbage collected until it fires.
+	defer timer.Stop()
 	var lastPingSent time.Time
 	// errCh should be buffered, so that the goroutine sending the error does not block if the context is cancelled
 	errCh := make(chan error, 1)
 	for {
 		select {
 		case <-ctx.Done():
-			timer.Stop() // We don't care if the timer has fired
 			return nil
 		case t := <-timer.C:
 			p.mu.Lock()
@@ -113,12 +114,15 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 			}
 			lastPingSent = time.Now()
 			go func() {
+				// WriteTo may not complete within KeepAlive period due to slow/unstable network.
+				// For instance, if a huge message is sent over a very slow link at the same time as PINGREQ packet,
+				// the Write operation may block for longer than KeepAlive interval.
+				// Note: connection closure unblocks the Write operation. So, the goroutine is not leaked.
 				if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(conn); err != nil {
 					p.debug.Printf("DefaultPinger packet write error: %v", err)
 					errCh <- fmt.Errorf("failed to send PINGREQ: %w", err)
 					return
 				}
-				errCh <- nil
 			}()
 			timer.Reset(interval)
 		case err := <-errCh:

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -121,14 +121,11 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 				if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(conn); err != nil {
 					p.debug.Printf("DefaultPinger packet write error: %v", err)
 					errCh <- fmt.Errorf("failed to send PINGREQ: %w", err)
-					return
 				}
 			}()
 			timer.Reset(interval)
 		case err := <-errCh:
-			if err != nil {
-				return err
-			}
+			return err
 		}
 	}
 }

--- a/paho/pinger.go
+++ b/paho/pinger.go
@@ -88,6 +88,8 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 	interval := time.Duration(keepAlive) * time.Second
 	timer := time.NewTimer(0) // Immediately send first pingreq
 	var lastPingSent time.Time
+	// errCh should be buffered, so that the goroutine sending the error does not block if the context is cancelled
+	errCh := make(chan error, 1)
 	for {
 		select {
 		case <-ctx.Done():
@@ -109,13 +111,20 @@ func (p *DefaultPinger) Run(ctx context.Context, conn net.Conn, keepAlive uint16
 				timer.Reset(pingDue.Sub(t))
 				continue
 			}
-
-			lastPingSent = time.Now() // set before sending because WriteTo may return after PINGRESP is handled
-			if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(conn); err != nil {
-				p.debug.Printf("DefaultPinger packet write error: %v", err)
-				return fmt.Errorf("failed to send PINGREQ: %w", err)
-			}
+			lastPingSent = time.Now()
+			go func() {
+				if _, err := packets.NewControlPacket(packets.PINGREQ).WriteTo(conn); err != nil {
+					p.debug.Printf("DefaultPinger packet write error: %v", err)
+					errCh <- fmt.Errorf("failed to send PINGREQ: %w", err)
+					return
+				}
+				errCh <- nil
+			}()
 			timer.Reset(interval)
+		case err := <-errCh:
+			if err != nil {
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Default PingHandler

### Current state
In order to detect network issues in the application layer, PingHandler sends a PINGREQ, and if it doesn't receive a response within the specified KeepAlive period, the connection is closed. However, if the network is very slow and unstable, the WriteTo(conn) operation (which sends a PINGREQ) may block for quite some time, during which context cancellation and KeepAlive timeout are ignored. The call must be eventually unblocked due to TCP timeouts. (Note: I have an example where connection establishment through the proxy hung for 1 hour; it's already fixed with proxy.Dial and ContextDialer. However, I suspect the same could happen here as well)
### Proposal
Send a PINGREQ request in a separate goroutine. In case of KeepAlive timeout or context cancellation, the main goroutine does not wait until the write operation finishes. The spawned goroutine will not be leaked if the connection is closed (this must unblock the write operation).