### PR TITLE
Add publish callback

### DIFF
--- a/autopaho/auto.go
+++ b/autopaho/auto.go
@@ -61,6 +61,8 @@ type PublishReceived struct {
 	ConnectionManager *ConnectionManager
 }
 
+type PublishCompleteCallback func(*paho.PublishResponse, error)
+
 // ClientConfig adds a few values, required to manage the connection, to the standard paho.ClientConfig (note that
 // conn will be ignored)
 type ClientConfig struct {
@@ -127,6 +129,9 @@ type ConnectionManager struct {
 
 	debug  log.Logger // By default set to NOOPLogger{},set to a logger for debugging info
 	errors log.Logger // By default set to NOOPLogger{},set to a logger for errors
+
+	callbackMap map[uint16]PublishCompleteCallback
+	callbackMu  sync.Mutex // protects the callbackmap
 }
 
 // ResetUsernamePassword clears any configured username and password on the client configuration
@@ -453,6 +458,7 @@ func (c *ConnectionManager) Publish(ctx context.Context, p *paho.Publish) (*paho
 // without breaking existing code
 type QueuePublish struct {
 	*paho.Publish
+	OnComplete PublishCompleteCallback
 }
 
 // PublishViaQueue is used to send a publication to the MQTT server via a queue (by default memory based).
@@ -471,7 +477,19 @@ func (c *ConnectionManager) PublishViaQueue(ctx context.Context, p *QueuePublish
 	if _, err := p.Packet().WriteTo(&b); err != nil {
 		return err
 	}
-	return c.queue.Enqueue(&b)
+	err := c.queue.Enqueue(&b)
+	if err != nil {
+		return err
+	}
+
+	// If a callback is provided, we need to track this publish
+	if p.OnComplete != nil {
+		c.callbackMu.Lock()
+		c.callbackMap[p.PacketID] = p.OnComplete
+		c.callbackMu.Unlock()
+	}
+
+	return nil
 }
 
 // TerminateConnectionForTest closes the active connection (if any). This function is intended for testing only, it
@@ -598,20 +616,26 @@ connectionLoop:
 					Payload:  pub.Payload,
 				}
 				pub2.InitProperties(pub.Properties)
+				asyncCompleteChan := make(chan packets.ControlPacket, 1)
 
 				// PublishWithOptions using PublishMethod_AsyncSend will block until the packet has been transmitted
 				// and then return (at this point any pub1+ publish will be in the session so will be retried)
 				c.debug.Printf("publishing message from queue with topic %s", pub2.Topic)
-				if _, err = cli.PublishWithOptions(ctx, &pub2, paho.PublishOptions{Method: paho.PublishMethod_AsyncSend}); err != nil {
+				var resp, pubErr = cli.PublishWithOptions(ctx, &pub2, paho.PublishOptions{Method: paho.PublishMethod_AsyncSend, AsyncCompleteChan: asyncCompleteChan})
+				if pubErr != nil {
 					c.errors.Printf("error publishing from queue: %s", err)
 					if errors.Is(err, paho.ErrInvalidArguments) { // Some errors should not be retried
 						if err := entry.Remove(); err != nil {
 							c.errors.Printf("error removing queue entry: %s", err)
+						} else {
+							go c.executeCallbackAndRemove(pub2.PacketID, resp, pubErr)
 						}
 						// Need a way to notify the user of this
 					} else if errors.Is(err, paho.ErrNetworkErrorAfterStored) { // Message in session so remove from queue
 						if err := entry.Remove(); err != nil {
 							c.errors.Printf("error removing queue entry: %s", err)
+						} else {
+							go c.handleAsyncCompletion(ctx, asyncCompleteChan, &pub2)
 						}
 					} else {
 						if err := entry.Leave(); err != nil { // the message was not sent, so leave it in the queue
@@ -634,8 +658,37 @@ connectionLoop:
 				if err := entry.Remove(); err != nil { // successfully published
 					c.errors.Printf("error removing queue entry: %s", err)
 					continue
+				} else if resp != nil {
+					go c.executeCallbackAndRemove(pub2.PacketID, resp, pubErr)
+				} else {
+					go c.handleAsyncCompletion(ctx, asyncCompleteChan, &pub2)
 				}
 			}
 		}
+	}
+}
+
+func (c *ConnectionManager) handleAsyncCompletion(ctx context.Context, asyncCompleteChan chan packets.ControlPacket, pub *paho.Publish) {
+	select {
+	case asyncResp := <-asyncCompleteChan:
+		c.debug.Printf("Async publish completed for topic %s", pub.Topic)
+		resp, pubError := c.cli.ProcessPublishResponse(asyncResp, pub.Packet())
+		c.executeCallbackAndRemove(pub.PacketID, resp, pubError)
+	case <-ctx.Done():
+		c.debug.Printf("Context cancelled while waiting for async publish completion for topic %s", pub.Topic)
+		c.executeCallbackAndRemove(pub.PacketID, nil, ctx.Err())
+	}
+}
+
+// write function to call onComplete and remove it from the callback map
+func (c *ConnectionManager) executeCallbackAndRemove(packetID uint16, resp *paho.PublishResponse, err error) {
+	c.callbackMu.Lock()
+	onComplete, ok := c.callbackMap[packetID]
+	if ok {
+		delete(c.callbackMap, packetID)
+		c.callbackMu.Unlock()
+		onComplete(resp, err)
+	} else {
+		c.callbackMu.Unlock()
 	}
 }

--- a/paho/client.go
+++ b/paho/client.go
@@ -833,7 +833,8 @@ const (
 // PublishOptions enables the behaviour of Publish to be modified
 type PublishOptions struct {
 	// Method enables a degree of control over how  PublishWithOptions operates
-	Method PublishMethod
+	Method            PublishMethod
+	AsyncCompleteChan chan packets.ControlPacket
 }
 
 // PublishWithOptions is used to send a publication to the MQTT server (with options to customise its behaviour)
@@ -886,8 +887,12 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish, o Publis
 	c.debug.Println("sending QoS12 message")
 	pubCtx, cf := context.WithTimeout(ctx, c.config.PacketTimeout)
 	defer cf()
-
-	ret := make(chan packets.ControlPacket, 1)
+	var ret chan packets.ControlPacket
+	if o.AsyncCompleteChan == nil {
+		ret = make(chan packets.ControlPacket, 1)
+	} else {
+		ret = o.AsyncCompleteChan
+	}
 	if err := c.config.Session.AddToSession(pubCtx, pb, ret); err != nil {
 		return nil, err
 	}
@@ -905,7 +910,6 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish, o Publis
 	if o.Method == PublishMethod_AsyncSend {
 		return nil, nil // Async send, so we don't wait for the response (may add callbacks in the future to enable user to obtain status)
 	}
-
 	var resp packets.ControlPacket
 	select {
 	case <-pubCtx.Done():
@@ -914,7 +918,10 @@ func (c *Client) publishQoS12(ctx context.Context, pb *packets.Publish, o Publis
 		return nil, ctxErr
 	case resp = <-ret:
 	}
+	return c.ProcessPublishResponse(resp, pb)
+}
 
+func (c *Client) ProcessPublishResponse(resp packets.ControlPacket, pb *packets.Publish) (*PublishResponse, error) {
 	if resp.Type == 0 { // default ControlPacket indicates we are shutting down
 		return nil, errors.New("PUBLISH transmitted but not fully acknowledged at time of shutdown")
 	}


### PR DESCRIPTION
Attempt 2 to get feedback on the logic.

Primarily, instead of the client creating the channel to receive the publish, I am making it at the `autopaho` level to ensure the channel can survive reconnects. 

TODO:
1. I wouldn't say I like mixing channels with callback, but I will think about how to merge them
2. Maybe there's a better way than exposing ProcessPublishResponse 
3. Better naming
4. Tests