### PR TITLE
Fix potential for packet corruption with very long strings/binary data

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -448,11 +448,19 @@ func writeUint32(u uint32, b *bytes.Buffer) error {
 }
 
 func writeString(s string, b *bytes.Buffer) {
+	// Due to the 16 bit header strings are limited to 65535 bytes
+	if len(s) > 65535 {
+		s = s[:65535]
+	}
 	writeUint16(uint16(len(s)), b)
 	b.WriteString(s)
 }
 
 func writeBinary(d []byte, b *bytes.Buffer) {
+	// Due to the 16 bit header strings are limited to 65535 bytes
+	if len(d) > 65535 {
+		d = d[:65535]
+	}
 	writeUint16(uint16(len(d)), b)
 	b.Write(d)
 }


### PR DESCRIPTION
Limit strings and binary data (not variable len encoded) to 65535 bytes. Prior to this the lentgh would have been corrupt and additional data would be written out.

closes #304
