### PR TITLE
perf: improve packets.ReadPacket performance

### DIFF
--- a/packets/packets.go
+++ b/packets/packets.go
@@ -307,18 +307,16 @@ func ReadPacket(r io.Reader) (*ControlPacket, error) {
 		return nil, err
 	}
 
-	var content bytes.Buffer
-	content.Grow(cp.remainingLength)
-
-	n, err := io.CopyN(&content, r, int64(cp.remainingLength))
+	b := make([]byte, cp.remainingLength)
+	n, err := io.ReadFull(r, b)
 	if err != nil {
 		return nil, err
 	}
 
-	if n != int64(cp.remainingLength) {
+	if n != cp.remainingLength {
 		return nil, fmt.Errorf("failed to read packet, expected %d bytes, read %d", cp.remainingLength, n)
 	}
-	err = cp.Content.Unpack(&content)
+	err = cp.Content.Unpack(bytes.NewBuffer(b))
 	if err != nil {
 		return nil, err
 	}
@@ -503,13 +501,12 @@ func readBinary(b *bytes.Buffer) ([]byte, error) {
 		return nil, err
 	}
 
-	var s bytes.Buffer
-	s.Grow(int(size))
-	if _, err := io.CopyN(&s, b, int64(size)); err != nil {
+	s := make([]byte, size)
+	if _, err := io.ReadFull(b, s); err != nil {
 		return nil, err
 	}
 
-	return s.Bytes(), nil
+	return s, nil
 }
 
 func readString(b *bytes.Buffer) (string, error) {

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -103,18 +103,21 @@ func TestDecodeVBI127(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 127, x)
 }
+
 func TestDecodeVBI128(t *testing.T) {
 	x, err := decodeVBI(bytes.NewBuffer([]byte{0x80, 0x01}))
 
 	require.Nil(t, err)
 	assert.Equal(t, 128, x)
 }
+
 func TestDecodeVBI16384(t *testing.T) {
 	x, err := decodeVBI(bytes.NewBuffer([]byte{0x80, 0x80, 0x01}))
 
 	require.Nil(t, err)
 	assert.Equal(t, 16384, x)
 }
+
 func TestDecodeVBIMax(t *testing.T) {
 	x, err := decodeVBI(bytes.NewBuffer([]byte{0xff, 0xff, 0xff, 0x7f}))
 
@@ -412,7 +415,8 @@ func TestControlPacket_PacketID(t *testing.T) {
 				Content:     &Unsuback{PacketID: 123},
 			},
 			want: 123,
-		}, {
+		},
+		{
 			name: "connect",
 			fields: fields{
 				FixedHeader: FixedHeader{Type: CONNECT},
@@ -515,4 +519,30 @@ func TestNewThreadSafeWrapper(t *testing.T) {
 	if _, ok := ts.(sync.Locker); !ok {
 		t.Error("NewThreadSafeConn does not implement sync.Locker")
 	}
+}
+
+func BenchmarkReadPacket(b *testing.B) {
+	benchmarkPacket := func(b *testing.B, name string, p Packet) {
+		b.Run(name, func(b *testing.B) {
+			buf := bytes.Buffer{}
+			_, err := p.WriteTo(&buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+			for b.Loop() {
+				_, err := ReadPacket(bytes.NewReader(buf.Bytes()))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+	benchmarkPacket(b, "small", &Puback{})
+	benchmarkPacket(b, "large", &Auth{
+		Properties: &Properties{
+			AuthMethod: "foo",
+			AuthData:   bytes.Repeat([]byte{123}, 1024),
+		},
+		ReasonCode: AuthReauthenticate,
+	})
 }


### PR DESCRIPTION
Replace a couple instances of io.CopyN with io.ReadFull to avoid the former's extra buffer allocations. This gives a surprisingly large performance boost.

```
goos: linux
goarch: amd64
pkg: github.com/eclipse/paho.golang/packets
cpu: Intel(R) Core(TM) Ultra 7 165H
                    │  before.txt  │             after.txt              │
                    │    sec/op    │   sec/op     vs base               │
ReadPacket/small-22   1109.0n ± 2%   575.8n ± 1%  -48.08% (p=0.000 n=8)
ReadPacket/large-22    3.395µ ± 1%   1.405µ ± 2%  -58.62% (p=0.000 n=8)
geomean                1.940µ        899.3n       -53.65%

                    │  before.txt  │              after.txt              │
                    │     B/op     │     B/op      vs base               │
ReadPacket/small-22    2315.0 ± 0%     696.0 ± 0%  -69.94% (p=0.000 n=8)
ReadPacket/large-22   8.826Ki ± 0%   2.853Ki ± 0%  -67.68% (p=0.000 n=8)
geomean               4.467Ki        1.392Ki       -68.83%

                    │ before.txt │             after.txt             │
                    │ allocs/op  │ allocs/op   vs base               │
ReadPacket/small-22   16.00 ± 0%   13.00 ± 0%  -18.75% (p=0.000 n=8)
ReadPacket/large-22   26.00 ± 0%   17.00 ± 0%  -34.62% (p=0.000 n=8)
geomean               20.40        14.87       -27.11%
```
**Testing**

Existing tests pass.

**Closing issues**

closes #320 