### PR TITLE
Check for invalid Variable Byte Integer when encoding/decoding

### DIFF
--- a/packets/auth.go
+++ b/packets/auth.go
@@ -73,14 +73,20 @@ func (a *Auth) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (a *Auth) Buffers() net.Buffers {
-	idvp := a.Properties.Pack(AUTH)
-	propLen := encodeVBI(len(idvp))
+func (a *Auth) Buffers() (net.Buffers, error) {
+	idvp, err := a.Properties.Pack(AUTH)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 	n := net.Buffers{[]byte{a.ReasonCode}, propLen}
 	if len(idvp) > 0 {
 		n = append(n, idvp)
 	}
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/connack.go
+++ b/packets/connack.go
@@ -80,7 +80,7 @@ func (c *Connack) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (c *Connack) Buffers() net.Buffers {
+func (c *Connack) Buffers() (net.Buffers, error) {
 	var header bytes.Buffer
 
 	if c.SessionPresent {
@@ -90,15 +90,21 @@ func (c *Connack) Buffers() net.Buffers {
 	}
 	header.WriteByte(c.ReasonCode)
 
-	idvp := c.Properties.Pack(CONNACK)
-	propLen := encodeVBI(len(idvp))
+	idvp, err := c.Properties.Pack(CONNACK)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 
 	n := net.Buffers{header.Bytes(), propLen}
 	if len(idvp) > 0 {
 		n = append(n, idvp)
 	}
 
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/disconnect.go
+++ b/packets/disconnect.go
@@ -87,14 +87,20 @@ func (d *Disconnect) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (d *Disconnect) Buffers() net.Buffers {
-	idvp := d.Properties.Pack(DISCONNECT)
-	propLen := encodeVBI(len(idvp))
+func (d *Disconnect) Buffers() (net.Buffers, error) {
+	idvp, err := d.Properties.Pack(DISCONNECT)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 	n := net.Buffers{[]byte{d.ReasonCode}, propLen}
 	if len(idvp) > 0 {
 		n = append(n, idvp)
 	}
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -30,14 +30,16 @@ import (
 )
 
 func TestEncodeVBI127(t *testing.T) {
-	b := encodeVBI(127)
+	b, err := encodeVBI(127)
+	require.NoError(t, err)
 
 	require.Len(t, b, 1)
 	assert.Equal(t, byte(127), b[0])
 }
 
 func TestEncodeVBI128(t *testing.T) {
-	b := encodeVBI(128)
+	b, err := encodeVBI(128)
+	require.NoError(t, err)
 
 	require.Len(t, b, 2)
 	assert.Equal(t, byte(0x80), b[0])
@@ -45,7 +47,8 @@ func TestEncodeVBI128(t *testing.T) {
 }
 
 func TestEncodeVBI16383(t *testing.T) {
-	b := encodeVBI(16383)
+	b, err := encodeVBI(16383)
+	require.NoError(t, err)
 
 	require.Len(t, b, 2)
 	assert.Equal(t, byte(0xff), b[0])
@@ -53,7 +56,8 @@ func TestEncodeVBI16383(t *testing.T) {
 }
 
 func TestEncodeVBI16384(t *testing.T) {
-	b := encodeVBI(16384)
+	b, err := encodeVBI(16384)
+	require.NoError(t, err)
 
 	require.Len(t, b, 3)
 	assert.Equal(t, byte(0x80), b[0])
@@ -62,7 +66,8 @@ func TestEncodeVBI16384(t *testing.T) {
 }
 
 func TestEncodeVBI2097151(t *testing.T) {
-	b := encodeVBI(2097151)
+	b, err := encodeVBI(2097151)
+	require.NoError(t, err)
 
 	require.Len(t, b, 3)
 	assert.Equal(t, byte(0xff), b[0])
@@ -71,7 +76,8 @@ func TestEncodeVBI2097151(t *testing.T) {
 }
 
 func TestEncodeVBI2097152(t *testing.T) {
-	b := encodeVBI(2097152)
+	b, err := encodeVBI(2097152)
+	require.NoError(t, err)
 
 	require.Len(t, b, 4)
 	assert.Equal(t, byte(0x80), b[0])
@@ -81,13 +87,24 @@ func TestEncodeVBI2097152(t *testing.T) {
 }
 
 func TestEncodeVBIMax(t *testing.T) {
-	b := encodeVBI(268435455)
+	b, err := encodeVBI(268435455)
+	require.NoError(t, err)
 
 	require.Len(t, b, 4)
 	assert.Equal(t, byte(0xff), b[0])
 	assert.Equal(t, byte(0xff), b[1])
 	assert.Equal(t, byte(0xff), b[2])
 	assert.Equal(t, byte(0x7f), b[3])
+}
+
+func TestEncodeVBIMaxPlus1(t *testing.T) {
+	_, err := encodeVBI(268435456)
+	require.Error(t, err)
+}
+
+func TestEncodeVBIdirectMaxPlus1(t *testing.T) {
+	err := encodeVBIdirect(268435456, nil) // nil buffer OK as nothing should be written to it
+	require.ErrorContains(t, err, "invalid VBI length")
 }
 
 func TestDecodeVBI12(t *testing.T) {
@@ -121,7 +138,14 @@ func TestDecodeVBIMax(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 268435455, x)
 }
-
+func TestDecodeVBIMaxPlus1(t *testing.T) {
+	_, err := decodeVBI(bytes.NewBuffer([]byte{0xff, 0xff, 0xff, 0x80}))
+	require.Error(t, err)
+}
+func TestDecodeGetVBIMaxPlus1(t *testing.T) {
+	_, err := getVBI(bytes.NewBuffer([]byte{0xff, 0xff, 0xff, 0x80}))
+	require.ErrorContains(t, err, "malformed Variable Byte Integer")
+}
 func TestNewControlPacketConnect(t *testing.T) {
 	var b bytes.Buffer
 	x := NewControlPacket(CONNECT)

--- a/packets/pingreq.go
+++ b/packets/pingreq.go
@@ -35,8 +35,8 @@ func (p *Pingreq) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Pingreq) Buffers() net.Buffers {
-	return nil
+func (p *Pingreq) Buffers() (net.Buffers, error) {
+	return nil, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/pingresp.go
+++ b/packets/pingresp.go
@@ -35,8 +35,8 @@ func (p *Pingresp) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Pingresp) Buffers() net.Buffers {
-	return nil
+func (p *Pingresp) Buffers() (net.Buffers, error) {
+	return nil, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/properties.go
+++ b/packets/properties.go
@@ -243,11 +243,11 @@ func (p *Properties) String() string {
 
 // Pack takes all the defined properties for an Properties and produces
 // a slice of bytes representing the wire format for the information
-func (i *Properties) Pack(p byte) []byte {
+func (i *Properties) Pack(p byte) ([]byte, error) {
 	var b bytes.Buffer
 
 	if i == nil {
-		return nil
+		return nil, nil // nothing to write
 	}
 
 	if p == PUBLISH {
@@ -285,7 +285,9 @@ func (i *Properties) Pack(p byte) []byte {
 	if p == PUBLISH || p == SUBSCRIBE {
 		if i.SubscriptionIdentifier != nil {
 			b.WriteByte(PropSubscriptionIdentifier)
-			encodeVBIdirect(*i.SubscriptionIdentifier, &b)
+			if err := encodeVBIdirect(*i.SubscriptionIdentifier, &b); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -404,18 +406,18 @@ func (i *Properties) Pack(p byte) []byte {
 		writeString(v.Value, &b)
 	}
 
-	return b.Bytes()
+	return b.Bytes(), nil
 }
 
 // PackBuf will create a bytes.Buffer of the packed properties, it
 // will only pack the properties appropriate to the packet type p
 // even though other properties may exist, it will silently ignore
 // them
-func (i *Properties) PackBuf(p byte) *bytes.Buffer {
+func (i *Properties) PackBuf(p byte) (*bytes.Buffer, error) {
 	var b bytes.Buffer
 
 	if i == nil {
-		return nil
+		return nil, nil
 	}
 
 	if p == PUBLISH {
@@ -453,7 +455,9 @@ func (i *Properties) PackBuf(p byte) *bytes.Buffer {
 	if p == PUBLISH || p == SUBSCRIBE {
 		if i.SubscriptionIdentifier != nil {
 			b.WriteByte(PropSubscriptionIdentifier)
-			encodeVBIdirect(*i.SubscriptionIdentifier, &b)
+			if err := encodeVBIdirect(*i.SubscriptionIdentifier, &b); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -572,7 +576,7 @@ func (i *Properties) PackBuf(p byte) *bytes.Buffer {
 		writeString(v.Value, &b)
 	}
 
-	return &b
+	return &b, nil
 }
 
 // Unpack takes a buffer of bytes and reads out the defined properties

--- a/packets/puback.go
+++ b/packets/puback.go
@@ -82,17 +82,23 @@ func (p *Puback) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Puback) Buffers() net.Buffers {
+func (p *Puback) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(p.PacketID, &b)
 	b.WriteByte(p.ReasonCode)
-	idvp := p.Properties.Pack(PUBACK)
-	propLen := encodeVBI(len(idvp))
+	idvp, err := p.Properties.Pack(PUBACK)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 	n := net.Buffers{b.Bytes(), propLen}
 	if len(idvp) > 0 {
 		n = append(n, idvp)
 	}
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/pubcomp.go
+++ b/packets/pubcomp.go
@@ -75,18 +75,24 @@ func (p *Pubcomp) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Pubcomp) Buffers() net.Buffers {
+func (p *Pubcomp) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(p.PacketID, &b)
 	b.WriteByte(p.ReasonCode)
 	n := net.Buffers{b.Bytes()}
-	idvp := p.Properties.Pack(PUBCOMP)
-	propLen := encodeVBI(len(idvp))
+	idvp, err := p.Properties.Pack(PUBCOMP)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 	if len(idvp) > 0 {
 		n = append(n, propLen)
 		n = append(n, idvp)
 	}
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/publish.go
+++ b/packets/publish.go
@@ -76,15 +76,20 @@ func (p *Publish) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Publish) Buffers() net.Buffers {
+func (p *Publish) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeString(p.Topic, &b)
 	if p.QoS > 0 {
 		_ = writeUint16(p.PacketID, &b)
 	}
-	idvp := p.Properties.Pack(PUBLISH)
-	encodeVBIdirect(len(idvp), &b)
-	return net.Buffers{b.Bytes(), idvp, p.Payload}
+	idvp, err := p.Properties.Pack(PUBLISH)
+	if err != nil {
+		return nil, err
+	}
+	if err := encodeVBIdirect(len(idvp), &b); err != nil {
+		return nil, err
+	}
+	return net.Buffers{b.Bytes(), idvp, p.Payload}, nil
 
 }
 

--- a/packets/pubrec.go
+++ b/packets/pubrec.go
@@ -83,18 +83,24 @@ func (p *Pubrec) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Pubrec) Buffers() net.Buffers {
+func (p *Pubrec) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(p.PacketID, &b)
 	b.WriteByte(p.ReasonCode)
 	n := net.Buffers{b.Bytes()}
-	idvp := p.Properties.Pack(PUBREC)
-	propLen := encodeVBI(len(idvp))
+	idvp, err := p.Properties.Pack(PUBREC)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 	if len(idvp) > 0 {
 		n = append(n, propLen)
 		n = append(n, idvp)
 	}
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/pubrel.go
+++ b/packets/pubrel.go
@@ -69,18 +69,24 @@ func (p *Pubrel) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (p *Pubrel) Buffers() net.Buffers {
+func (p *Pubrel) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(p.PacketID, &b)
 	b.WriteByte(p.ReasonCode)
 	n := net.Buffers{b.Bytes()}
-	idvp := p.Properties.Pack(PUBREL)
-	propLen := encodeVBI(len(idvp))
+	idvp, err := p.Properties.Pack(PUBREL)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
 	if len(idvp) > 0 {
 		n = append(n, propLen)
 		n = append(n, idvp)
 	}
-	return n
+	return n, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/suback.go
+++ b/packets/suback.go
@@ -68,12 +68,18 @@ func (s *Suback) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (s *Suback) Buffers() net.Buffers {
+func (s *Suback) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(s.PacketID, &b)
-	idvp := s.Properties.Pack(SUBACK)
-	propLen := encodeVBI(len(idvp))
-	return net.Buffers{b.Bytes(), propLen, idvp, s.Reasons}
+	idvp, err := s.Properties.Pack(SUBACK)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
+	return net.Buffers{b.Bytes(), propLen, idvp, s.Reasons}, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/subscribe.go
+++ b/packets/subscribe.go
@@ -129,7 +129,7 @@ func (s *Subscribe) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (s *Subscribe) Buffers() net.Buffers {
+func (s *Subscribe) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(s.PacketID, &b)
 	var subs bytes.Buffer
@@ -137,9 +137,15 @@ func (s *Subscribe) Buffers() net.Buffers {
 		writeString(o.Topic, &subs)
 		subs.WriteByte(o.Pack())
 	}
-	idvp := s.Properties.Pack(SUBSCRIBE)
-	propLen := encodeVBI(len(idvp))
-	return net.Buffers{b.Bytes(), propLen, idvp, subs.Bytes()}
+	idvp, err := s.Properties.Pack(SUBSCRIBE)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
+	return net.Buffers{b.Bytes(), propLen, idvp, subs.Bytes()}, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/unsuback.go
+++ b/packets/unsuback.go
@@ -63,12 +63,18 @@ func (u *Unsuback) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (u *Unsuback) Buffers() net.Buffers {
+func (u *Unsuback) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(u.PacketID, &b)
-	idvp := u.Properties.Pack(UNSUBACK)
-	propLen := encodeVBI(len(idvp))
-	return net.Buffers{b.Bytes(), propLen, idvp, u.Reasons}
+	idvp, err := u.Properties.Pack(UNSUBACK)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
+	return net.Buffers{b.Bytes(), propLen, idvp, u.Reasons}, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet

--- a/packets/unsubscribe.go
+++ b/packets/unsubscribe.go
@@ -71,16 +71,22 @@ func (u *Unsubscribe) Unpack(r *bytes.Buffer) error {
 }
 
 // Buffers is the implementation of the interface required function for a packet
-func (u *Unsubscribe) Buffers() net.Buffers {
+func (u *Unsubscribe) Buffers() (net.Buffers, error) {
 	var b bytes.Buffer
 	writeUint16(u.PacketID, &b)
 	var topics bytes.Buffer
 	for _, t := range u.Topics {
 		writeString(t, &topics)
 	}
-	idvp := u.Properties.Pack(UNSUBSCRIBE)
-	propLen := encodeVBI(len(idvp))
-	return net.Buffers{b.Bytes(), propLen, idvp, topics.Bytes()}
+	idvp, err := u.Properties.Pack(UNSUBSCRIBE)
+	if err != nil {
+		return nil, err
+	}
+	propLen, err := encodeVBI(len(idvp))
+	if err != nil {
+		return nil, err
+	}
+	return net.Buffers{b.Bytes(), propLen, idvp, topics.Bytes()}, nil
 }
 
 // WriteTo is the implementation of the interface required function for a packet


### PR DESCRIPTION
The Variable Byte Integer header can only be four bytes long; this limits the maximum length of the encoded data to 268,435,455 bytes. We should check this when decoding (important) and encoding (not so important but not checking could result in an invalid packet being sent). Checking for this required further changes as the library previously assumed that there are no errs on encoding (previously would panic if VBI was over length).