### PR TITLE
fix(rpc): free correlation entry when a request gets no response

### DIFF
--- a/paho/extensions/rpc/rpc.go
+++ b/paho/extensions/rpc/rpc.go
@@ -76,11 +76,22 @@ func (h *Handler) getCorrelIDChan(cID string) chan *paho.Publish {
 	return rChan
 }
 
+func (h *Handler) removeCorrelID(cID string) {
+	h.Lock()
+	defer h.Unlock()
+
+	delete(h.correlData, cID)
+}
+
 func (h *Handler) Request(ctx context.Context, pb *paho.Publish) (*paho.Publish, error) {
 	cID := fmt.Sprintf("%d", time.Now().UnixNano())
 	rChan := make(chan *paho.Publish, 1) // Buffered to prevent goroutine leak when context cancelled
 
 	h.addCorrelID(cID, rChan)
+	// Ensure the correlation entry is always removed. responseHandler only
+	// removes it when a matching response arrives, so without this a request
+	// that times out, is cancelled, or fails to publish leaks a map entry.
+	defer h.removeCorrelID(cID)
 
 	if pb.Properties == nil {
 		pb.Properties = &paho.PublishProperties{}

--- a/paho/extensions/rpc/rpc_test.go
+++ b/paho/extensions/rpc/rpc_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    https://www.eclipse.org/legal/epl-2.0/
+ *  and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ *  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package rpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.golang/internal/basictestserver"
+	"github.com/eclipse/paho.golang/packets"
+	"github.com/eclipse/paho.golang/paho"
+	paholog "github.com/eclipse/paho.golang/paho/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequestCleansUpCorrelDataOnTimeout is a regression test for issue #313:
+// a Request whose response never arrives (timeout/cancel) must not leak its
+// correlation-data entry. Previously the entry was only removed when a matching
+// response was received, so every timed-out request leaked a map entry + channel.
+func TestRequestCleansUpCorrelDataOnTimeout(t *testing.T) {
+	ts := basictestserver.New(paholog.NOOPLogger{})
+	ts.SetResponse(packets.CONNACK, &packets.Connack{ReasonCode: 0, Properties: &packets.Properties{}})
+	ts.SetResponse(packets.SUBACK, &packets.Suback{Reasons: []byte{1}, Properties: &packets.Properties{}})
+	ts.SetResponse(packets.PUBACK, &packets.Puback{Properties: &packets.Properties{}})
+	go ts.Run()
+	defer ts.Stop()
+
+	c := paho.NewClient(paho.ClientConfig{
+		Conn:     ts.ClientConn(),
+		ClientID: "testRPC",
+	})
+	_, err := c.Connect(context.Background(), &paho.Connect{
+		ClientID:   "testRPC",
+		KeepAlive:  30,
+		CleanStart: true,
+	})
+	require.NoError(t, err)
+
+	h, err := NewHandler(context.Background(), c)
+	require.NoError(t, err)
+
+	// The server auto-acks the PUBLISH but never sends a response on the
+	// response topic, so the Request must time out.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err = h.Request(ctx, &paho.Publish{Topic: "test/request", QoS: 1, Payload: []byte("ping")})
+	require.Error(t, err, "Request should fail when no response arrives")
+
+	h.Lock()
+	n := len(h.correlData)
+	h.Unlock()
+	require.Equal(t, 0, n, "correlData entry must be removed after a timed-out request (issue #313)")
+}


### PR DESCRIPTION
## Summary

Closes #313.

`rpc.Handler.Request` registers a correlation entry (`cID -> response channel`) in `h.correlData`, but that entry is only ever removed by `responseHandler` — i.e. when a matching response actually arrives. Any request that:

- times out / has its context cancelled (`<-ctx.Done()`), or
- fails to publish (`h.c.Publish` returns an error), or
- never receives a response

leaves its entry in `h.correlData` forever. Over a long-running session with any lost/slow responses this is a steady memory leak (one map entry + channel per affected request).

The earlier buffered-channel change fixed the goroutine leak on cancellation, but the map entry itself was still leaked.

## Fix

Add `removeCorrelID` and `defer` it at the top of `Request`, so the correlation entry is removed on every exit path (response received, timeout, cancel, publish error). `delete` on an already-removed key is a no-op, so this is safe alongside `responseHandler`'s removal.

## Testing

Added `TestRequestCleansUpCorrelDataOnTimeout` (uses the existing `basictestserver`): connect, create the handler, then issue a `Request` that is acked at the PUBLISH level but never gets a response on the response topic, so it times out. It asserts `len(h.correlData) == 0` afterwards.

- Verified the test **fails without** this change (`correlData` length is 1) and **passes with** it.
- `go test ./paho/extensions/rpc/ -race` passes; `go vet` clean; `gofmt` clean.

## Note (separate, not addressed here)

`Request` derives the correlation ID from `time.Now().UnixNano()`, so two concurrent requests issued within the same nanosecond can collide on the same `cID` (one overwrites the other's channel, and that caller then hangs until its context fires). Happy to follow up with a counter/UUID-based ID in a separate PR if you'd like — kept this one focused on the #313 leak.
