### PR TITLE
fix(state): use a signed send quota so retransmit cannot underflow

### DIFF
--- a/paho/session/state/sendquota.go
+++ b/paho/session/state/sendquota.go
@@ -46,16 +46,21 @@ var ErrUnexpectedRelease = errors.New("release called when quota at initial valu
 
 // newSendQuota creates a new tracker limited to quota concurrent messages
 func newSendQuota(quota uint16) *sendQuota {
-	w := &sendQuota{initialQuota: quota, quota: quota}
+	w := &sendQuota{initialQuota: int(quota), quota: int(quota)}
 	return w
 }
 
 // sendQuota provides a way to bound concurrent access to a resource.
 // The callers can request access with a given weight.
+//
+// quota is a signed counter: Retransmit (noWait) decrements it without blocking, so on a
+// reconnect that retransmits more stored messages than the receive maximum it can legitimately
+// go negative (over-allocated). It must therefore be a signed type — a uint16 here would wrap to
+// a large value, permanently defeating the receive-maximum bound and breaking Release.
 type sendQuota struct {
 	mu           sync.Mutex
-	initialQuota uint16
-	quota        uint16
+	initialQuota int
+	quota        int
 	waiters      []chan<- struct{} // using a slice because would generally expect this to be small
 }
 

--- a/paho/session/state/sendquota_test.go
+++ b/paho/session/state/sendquota_test.go
@@ -225,3 +225,40 @@ func TestQuotaLoad(t *testing.T) {
 		t.Fatalf("expected waiters to be empty: %v", it.waiters)
 	}
 }
+
+// TestQuotaRetransmitDoesNotUnderflow is a regression test: on reconnect the session
+// retransmits each stored (unacknowledged) message via Retransmit, which decrements the
+// quota without blocking. If more messages are stored than the receive maximum, the quota
+// must go negative (over-allocated) rather than wrapping around. With the previous uint16
+// quota it underflowed to a huge value, so Release returned ErrUnexpectedRelease and the
+// receive-maximum bound was permanently lost.
+func TestQuotaRetransmitDoesNotUnderflow(t *testing.T) {
+	t.Parallel()
+
+	const receiveMax = 2
+	it := newSendQuota(receiveMax)
+
+	// Retransmit one more message than the receive maximum allows.
+	for i := 0; i < receiveMax+1; i++ {
+		if err := it.Retransmit(); err != nil {
+			t.Fatalf("Retransmit %d: %v", i, err)
+		}
+	}
+
+	// Releasing the (over-allocated) slots must succeed and bring the quota back to its
+	// initial value. If the quota had underflowed, Release would return ErrUnexpectedRelease.
+	for i := 0; i < receiveMax+1; i++ {
+		if err := it.Release(); err != nil {
+			t.Fatalf("Release %d returned %v; quota underflowed instead of going negative", i, err)
+		}
+	}
+
+	if it.quota != receiveMax {
+		t.Fatalf("expected quota restored to %d, got %d", receiveMax, it.quota)
+	}
+
+	// Back at the initial value: a further Release is unexpected.
+	if err := it.Release(); err != ErrUnexpectedRelease {
+		t.Fatalf("expected ErrUnexpectedRelease at initial quota, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`sendQuota.quota` and `initialQuota` are `uint16`, but the send-quota was designed around a counter that can go **negative** — the code's own comments say so (`// Note: can go < 0 if noWait used` in `acquire`, and `// Possible quota could go negative when using noWait` in `Release`). On an unsigned type it can't go negative; it wraps.

`Retransmit()` calls `acquire(ctx, noWait=true)`, which unconditionally does `s.quota--` without blocking. On a reconnect, `ConAckReceived` creates a fresh `newSendQuota(recvMax)` and then calls `Retransmit()` once per stored (unacknowledged) message (`state.go`). If there are more stored messages than the receive maximum, the quota is decremented past zero and **wraps to ~65535**. After that:

- `Acquire` always sees `quota > 0`, so it stops blocking — the broker's **Receive Maximum is no longer honoured** (the client can exceed it).
- `Release` is broken: `s.quota < s.initialQuota` is false (65535 < recvMax), so it never decrements back and returns `ErrUnexpectedRelease` indefinitely; the quota never recovers.

### Trigger (normal usage)

A client that buffers several QoS 1/2 publishes while disconnected and then reconnects, where the backlog exceeds the broker's (possibly small) receive maximum.

## Fix

Make `quota` and `initialQuota` signed (`int`) so the counter can legitimately go negative (over-allocated) as the existing comments intend, instead of wrapping. The existing `Acquire`/`Release` logic (`quota >= 0`, `quota < initialQuota`) then behaves correctly: releases bring the over-allocated quota back up to the initial value.

## Testing

Added `TestQuotaRetransmitDoesNotUnderflow`: `newSendQuota(2)`, `Retransmit()` 3 times (one past the max), then `Release()` must succeed back to the initial value (rather than returning `ErrUnexpectedRelease`). Verified it **fails before** this change and **passes after**. The existing quota tests still pass.

- `go test ./paho/session/state/ -race` and `go test ./paho/ -race` pass; `gofmt` clean.
